### PR TITLE
chore: clear up the exit in the router class, add `env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PANEL_USERNAME = "admin"
+PANEL_PASSWORD = "1234"
+PPPOE_USERNAME = "pppoe_user"
+PPPOE_PASSWORD = "pppoe_pass"

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -1,10 +1,19 @@
 import os
 import dotenv  # type: ignore[import-not-found]
+import logging
 
 dotenv.load_dotenv()
 
+logger = logging.getLogger(__name__)
+
 PANEL_USERNAME: str = os.getenv("PANEL_USERNAME") or "admin"
-PANEL_PASSWORD: str | None = os.getenv("PANEL_PASSWORD") or None
+
+_PANEL_PASSWORD: str | None = os.getenv("PANEL_PASSWORD")
+if _PANEL_PASSWORD is None:
+    logger.error("Error: PANEL_PASSWORD environment variable is not set.")
+    exit(1)
+
+PANEL_PASSWORD: str = _PANEL_PASSWORD
 PPPOE_USERNAME: str | None = os.getenv("PPPOE_USERNAME") or None
 PPPOE_PASSWORD: str | None = os.getenv("PPPOE_PASSWORD") or None
 ASN: str | None = os.getenv("ASN") or None

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -2,7 +2,13 @@ import os
 import dotenv  # type: ignore[import-not-found]
 import logging
 
-env_file = dotenv.find_dotenv(filename=".env.example" or ".env")
+file_name = ".env.example" if not os.path.exists(".env") else ".env"
+if file_name == ".env.example":
+    logging.warning(
+        "Warning: .env file not found. Using .env.example as fallback."
+        "Please create a .env file with the necessary environment variables."
+    )
+env_file = dotenv.find_dotenv(filename=file_name)
 dotenv.load_dotenv(env_file)
 
 logger = logging.getLogger(__name__)

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -2,7 +2,7 @@ import os
 import dotenv  # type: ignore[import-not-found]
 import logging
 
-env_file = ".env" if os.path.exists(".env") else ".env.example"
+env_file = dotenv.find_dotenv(filename=".env.example" or ".env")
 dotenv.load_dotenv(env_file)
 
 logger = logging.getLogger(__name__)

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -2,7 +2,8 @@ import os
 import dotenv  # type: ignore[import-not-found]
 import logging
 
-dotenv.load_dotenv()
+env_file = ".env" if os.path.exists(".env") else ".env.example"
+dotenv.load_dotenv(env_file)
 
 logger = logging.getLogger(__name__)
 

--- a/src/autodialer/network/get_gateway.py
+++ b/src/autodialer/network/get_gateway.py
@@ -57,11 +57,15 @@ def format_ip_for_url_host(value: str) -> str:
     return parsed.compressed
 
 
-def _get_gateway_ip_unsupported() -> str | None:
-    return None
+def _get_gateway_ip_unsupported() -> str:
+    logger.error(
+        "Unsupported platform: %s. Cannot determine default gateway IP address.",
+        platform.system(),
+    )
+    exit(1)
 
 
-def get_gateway_ip_on_windows() -> str | None:
+def get_gateway_ip_on_windows() -> str:
     try:
         result = subprocess.run(
             ["route", "print", "-4"],
@@ -69,8 +73,9 @@ def get_gateway_ip_on_windows() -> str | None:
             text=True,
             check=False,
         )
-    except OSError:
-        return None
+    except OSError as e:
+        logger.error("Failed to execute 'route print -4': %s", e)
+        exit(1)
 
     for line in result.stdout.splitlines():
         fields = line.split()
@@ -80,10 +85,11 @@ def get_gateway_ip_on_windows() -> str | None:
             gateway = fields[2]
             if _is_ip_address(gateway):
                 return gateway
-    return None
+    logger.error("Default gateway not found in 'route print -4' output.")
+    exit(1)
 
 
-def get_gateway_ip_on_linux() -> str | None:
+def get_gateway_ip_on_linux() -> str:
     try:
         with open("/proc/net/route", "r", encoding="utf-8") as routes:
             next(routes, None)
@@ -113,8 +119,9 @@ def get_gateway_ip_on_linux() -> str | None:
             text=True,
             check=False,
         )
-    except OSError:
-        return None
+    except OSError as e:
+        logger.error("Failed to execute 'ip -4 route show default': %s", e)
+        exit(1)
 
     for line in result.stdout.splitlines():
         fields = line.split()
@@ -131,10 +138,11 @@ def get_gateway_ip_on_linux() -> str | None:
         parsed_gateway = _extract_first_ip(fields[1:])
         if parsed_gateway is not None:
             return parsed_gateway
-    return None
+    logger.error("Default gateway not found in 'ip -4 route show default' output.")
+    exit(1)
 
 
-def get_gateway_ip_on_unix() -> str | None:
+def get_gateway_ip_on_unix() -> str:
     try:
         result = subprocess.run(
             ["route", "-n", "get", "default"],
@@ -142,8 +150,9 @@ def get_gateway_ip_on_unix() -> str | None:
             text=True,
             check=False,
         )
-    except OSError:
-        result = None
+    except OSError as e:
+        logger.error("Failed to execute 'route -n get default': %s", e)
+        exit(1)
 
     if result is not None:
         for line in result.stdout.splitlines():
@@ -161,8 +170,9 @@ def get_gateway_ip_on_unix() -> str | None:
             text=True,
             check=False,
         )
-    except OSError:
-        return None
+    except OSError as e:
+        logger.error("Failed to execute 'netstat -rn': %s", e)
+        exit(1)
 
     for line in result.stdout.splitlines():
         fields = line.split()
@@ -176,11 +186,14 @@ def get_gateway_ip_on_unix() -> str | None:
         gateway = _extract_first_ip(fields[1:])
         if gateway is not None:
             return gateway
-    return None
+    logger.error(
+        "Default gateway not found in 'route -n get default' or 'netstat -rn' output."
+    )
+    exit(1)
 
 
 platform_system = platform.system()
-get_gateway_ip: Callable[[], str | None]
+get_gateway_ip: Callable[[], str]
 if platform_system == "Windows":
     get_gateway_ip = get_gateway_ip_on_windows
 elif platform_system == "Linux":

--- a/src/autodialer/routers/asus/asus_api.py
+++ b/src/autodialer/routers/asus/asus_api.py
@@ -37,17 +37,8 @@ class AsusAPI(RouterAPI):
     verify_ssl: bool
 
     def __init__(self):
-        router_ip = get_gateway_ip()
-        if router_ip is None:
-            logger.error("Could not determine router IP address.")
-            exit(1)
-
-        if PANEL_PASSWORD is None:
-            logger.error("Missing required environment variable: PANEL_PASSWORD")
-            exit(1)
-
-        self.router_ip = router_ip
-        self.panel_username = PANEL_USERNAME or "admin"
+        self.router_ip = get_gateway_ip()
+        self.panel_username = PANEL_USERNAME
         self.panel_password = PANEL_PASSWORD
         self.session = requests.Session()
         self.base_url, self.verify_ssl, self.token = self._login_router()

--- a/src/autodialer/routers/tplink/tplink_api.py
+++ b/src/autodialer/routers/tplink/tplink_api.py
@@ -41,20 +41,9 @@ class TPLinkAPI(RouterAPI):
     stok: str | None = None
 
     def __init__(self):
-        router_ip = get_gateway_ip()
-        if router_ip is None:
-            logger.error("Could not determine router IP address.")
-            exit(1)
-
-        if PANEL_PASSWORD is None:
-            logger.error("Missing required environment variable: PANEL_PASSWORD")
-            exit(1)
-
-        panel_password: str = PANEL_PASSWORD
-
-        self.router_ip = router_ip
+        self.router_ip = get_gateway_ip()
         self.session = requests.Session()
-        self.password = tplink_security_encode(panel_password)
+        self.password = tplink_security_encode(PANEL_PASSWORD)
         self.username = PPPOE_USERNAME or ""
         self.pppoe_password = PPPOE_PASSWORD or ""
         self.stok = self.__login_router()

--- a/src/autodialer/routers/zte/zte_api.py
+++ b/src/autodialer/routers/zte/zte_api.py
@@ -22,11 +22,7 @@ class ZTEApi(RouterAPI):
     )
 
     def __init__(self):
-        router_ip = get_gateway_ip()
-        if router_ip is None:
-            logger.error("Could not determine router IP address.")
-            exit(1)
-        self.router_host = format_ip_for_url_host(router_ip)
+        self.router_host = format_ip_for_url_host(get_gateway_ip())
         self.session = requests.Session()
         self._seed_browser_cookies()
         if not self._authenticate():

--- a/tests/test_get_gateway.py
+++ b/tests/test_get_gateway.py
@@ -73,24 +73,6 @@ class TestGetGatewayIp(unittest.TestCase):
 
         self.assertEqual(result, "172.16.0.1")
 
-    @patch("autodialer.network.get_gateway.subprocess.run")
-    def test_no_gateway_returns_none_windows_and_unix(self, mock_run: Any):
-        mock_run.side_effect = [
-            Mock(stdout=""),
-            Mock(stdout=""),
-            Mock(stdout=""),
-        ]
-
-        self.assertIsNone(get_gateway_ip_on_windows())
-        self.assertIsNone(get_gateway_ip_on_unix())
-
-    @patch("autodialer.network.get_gateway.subprocess.run")
-    @patch("builtins.open", side_effect=OSError)
-    def test_no_gateway_returns_none_linux(self, _: Any, mock_run: Any):
-        mock_run.return_value = Mock(stdout="")
-
-        self.assertIsNone(get_gateway_ip_on_linux())
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
chore: clear up the exit in the router class, deleting the redundant if statement and exit(1) in the router class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now enforces required panel credentials and logs configuration errors; gateway resolution reports failures consistently.
  * Router integrations updated to centralize how missing network or credential values are handled during initialization.

* **Chores**
  * Added an example env file with panel and PPPoE entries.

* **Tests**
  * Removed tests covering previously supported "no gateway found" edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->