### PR TITLE
fix(config): fix method to find env_file

### DIFF
--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -2,16 +2,15 @@ import os
 import dotenv  # type: ignore[import-not-found]
 import logging
 
-file_name = ".env.example" if not os.path.exists(".env") else ".env"
-if file_name == ".env.example":
-    logging.warning(
-        "Warning: .env file not found. Using .env.example as fallback."
-        "Please create a .env file with the necessary environment variables."
-    )
-env_file = dotenv.find_dotenv(filename=file_name)
+logger = logging.getLogger(__name__)
+
+
+env_file = dotenv.find_dotenv()
+if env_file == "":
+    logger.warning("No .env file found! Please create one at root directory.")
+    env_file = dotenv.find_dotenv(".env.example")
 dotenv.load_dotenv(env_file)
 
-logger = logging.getLogger(__name__)
 
 PANEL_USERNAME: str = os.getenv("PANEL_USERNAME") or "admin"
 

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -7,8 +7,7 @@ logger = logging.getLogger(__name__)
 
 env_file = dotenv.find_dotenv()
 if env_file == "":
-    logger.warning("No .env file found! Please create one at root directory.")
-    env_file = dotenv.find_dotenv(".env.example")
+    raise RuntimeError("No .env file found! Please create one at root directory.")
 dotenv.load_dotenv(env_file)
 
 
@@ -17,7 +16,7 @@ PANEL_USERNAME: str = os.getenv("PANEL_USERNAME") or "admin"
 _PANEL_PASSWORD: str | None = os.getenv("PANEL_PASSWORD")
 if _PANEL_PASSWORD is None:
     logger.error("Error: PANEL_PASSWORD environment variable is not set.")
-    exit(1)
+    raise RuntimeError("Error: PANEL_PASSWORD environment variable is not set.")
 
 PANEL_PASSWORD: str = _PANEL_PASSWORD
 PPPOE_USERNAME: str | None = os.getenv("PPPOE_USERNAME") or None

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -7,11 +7,10 @@ logger = logging.getLogger(__name__)
 
 env_file = dotenv.find_dotenv()
 if env_file == "":
-    env_file = dotenv.find_dotenv(".env.example")
     logger.error(
-        ".env file not found. Using .env.example with default values. "
-        "Please create a .env file with appropriate values."
+        ".env file not found. Please create a .env file with appropriate values."
     )
+    exit(1)
 dotenv.load_dotenv(env_file)
 
 
@@ -20,7 +19,7 @@ PANEL_USERNAME: str = os.getenv("PANEL_USERNAME") or "admin"
 _PANEL_PASSWORD: str | None = os.getenv("PANEL_PASSWORD")
 if _PANEL_PASSWORD is None:
     logger.error("Error: PANEL_PASSWORD environment variable is not set.")
-    raise RuntimeError("Error: PANEL_PASSWORD environment variable is not set.")
+    exit(1)
 
 PANEL_PASSWORD: str = _PANEL_PASSWORD
 PPPOE_USERNAME: str | None = os.getenv("PPPOE_USERNAME") or None

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -7,7 +7,11 @@ logger = logging.getLogger(__name__)
 
 env_file = dotenv.find_dotenv()
 if env_file == "":
-    raise RuntimeError("No .env file found! Please create one at root directory.")
+    env_file = dotenv.find_dotenv(".env.example")
+    logger.error(
+        ".env file not found. Using .env.example with default values. "
+        "Please create a .env file with appropriate values."
+    )
 dotenv.load_dotenv(env_file)
 
 

--- a/src/autodialer/network/wait_internet_recovery.py
+++ b/src/autodialer/network/wait_internet_recovery.py
@@ -9,7 +9,6 @@ def try_connect(delay: int = 5, attempts: int = 5) -> bool:
     for _ in range(attempts):
         # Use a short-lived socket per probe so descriptors are always closed.
         with socket.socket() as sock:
-            sock.settimeout(5)
             connected = sock.connect_ex(("8.8.8.8", 53)) == 0
 
         if not connected:
@@ -27,6 +26,7 @@ def wait_internet_recovery(delay: int = 5, attempts: int = 5) -> None:
         return
 
 
+# For debugging purposes
 if __name__ == "__main__":
     if try_connect():
         print("success")

--- a/src/autodialer/network/wait_internet_recovery.py
+++ b/src/autodialer/network/wait_internet_recovery.py
@@ -5,17 +5,18 @@ from time import sleep
 logger = logging.getLogger(__name__)
 
 
-def try_connect(delay: int = 5, attempts: int = 5) -> bool:
+def try_connect(delay: int = 5, attempts: int = 3) -> bool:
     for _ in range(attempts):
-        try:
-            with socket.create_connection(("8.8.8.8", 53), timeout=delay):
-                return True
-        except OSError:
-            sleep(delay)
+        with socket.socket() as sock:
+            sock.settimeout(delay)
+            connected = sock.connect_ex(("8.8.8.8", 53)) == 0
+        if connected:
+            return True
+        sleep(delay)
     return False
 
 
-def wait_internet_recovery(delay: int = 5, attempts: int = 5) -> None:
+def wait_internet_recovery(delay: int = 5, attempts: int = 3) -> None:
     if try_connect(delay, attempts):
         return
     else:

--- a/src/autodialer/network/wait_internet_recovery.py
+++ b/src/autodialer/network/wait_internet_recovery.py
@@ -6,9 +6,12 @@ logger = logging.getLogger(__name__)
 
 
 def try_connect(delay: int = 5, attempts: int = 5) -> bool:
-    sock = socket.socket()
     for _ in range(attempts):
-        if sock.connect_ex(("8.8.8.8", 53)) != 0:
+        # Use a short-lived socket per probe so descriptors are always closed.
+        with socket.socket() as sock:
+            connected = sock.connect_ex(("8.8.8.8", 53)) == 0
+
+        if not connected:
             sleep(delay)
         else:
             return True

--- a/src/autodialer/network/wait_internet_recovery.py
+++ b/src/autodialer/network/wait_internet_recovery.py
@@ -19,9 +19,8 @@ def try_connect(delay: int = 5, attempts: int = 3) -> bool:
 def wait_internet_recovery(delay: int = 5, attempts: int = 3) -> None:
     if try_connect(delay, attempts):
         return
-    else:
-        logger.error("Internet did not recover within the expected time.")
-        return
+    logger.error("Internet did not recover within the expected time.")
+    return None
 
 
 # For debugging purposes

--- a/src/autodialer/network/wait_internet_recovery.py
+++ b/src/autodialer/network/wait_internet_recovery.py
@@ -7,14 +7,11 @@ logger = logging.getLogger(__name__)
 
 def try_connect(delay: int = 5, attempts: int = 5) -> bool:
     for _ in range(attempts):
-        # Use a short-lived socket per probe so descriptors are always closed.
-        with socket.socket() as sock:
-            connected = sock.connect_ex(("8.8.8.8", 53)) == 0
-
-        if not connected:
+        try:
+            with socket.create_connection(("8.8.8.8", 53), timeout=delay):
+                return True
+        except OSError:
             sleep(delay)
-        else:
-            return True
     return False
 
 

--- a/src/autodialer/network/wait_internet_recovery.py
+++ b/src/autodialer/network/wait_internet_recovery.py
@@ -9,6 +9,7 @@ def try_connect(delay: int = 5, attempts: int = 5) -> bool:
     for _ in range(attempts):
         # Use a short-lived socket per probe so descriptors are always closed.
         with socket.socket() as sock:
+            sock.settimeout(5)
             connected = sock.connect_ex(("8.8.8.8", 53)) == 0
 
         if not connected:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,7 @@ if str(SRC_PATH) not in sys.path:
 
 # Keep tests independent from local .env files and surrounding shell configuration.
 _DOTENV_PATCHERS = [
-    patch.dict(os.environ, {"PANEL_PASSWORD": "test-panel-password"}, clear=False),
+    patch.dict(os.environ, {"PANEL_PASSWORD": "test-panel-password"}, clear=True),
     patch("dotenv.find_dotenv", return_value=".env.mock"),
     patch("dotenv.load_dotenv", return_value=True),
 ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,30 @@
 from pathlib import Path
 import sys
+import atexit
+import os
+from unittest.mock import patch
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = PROJECT_ROOT / "src"
 
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
+
+# Keep tests independent from local .env files.
+os.environ.setdefault("PANEL_PASSWORD", "test-panel-password")
+
+_DOTENV_PATCHERS = [
+    patch("dotenv.find_dotenv", return_value=".env.mock"),
+    patch("dotenv.load_dotenv", return_value=True),
+]
+
+for _patcher in _DOTENV_PATCHERS:
+    _patcher.start()
+
+
+def _stop_dotenv_patchers() -> None:
+    for _patcher in reversed(_DOTENV_PATCHERS):
+        _patcher.stop()
+
+
+atexit.register(_stop_dotenv_patchers)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,10 +10,9 @@ SRC_PATH = PROJECT_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
-# Keep tests independent from local .env files.
-os.environ.setdefault("PANEL_PASSWORD", "test-panel-password")
-
+# Keep tests independent from local .env files and surrounding shell configuration.
 _DOTENV_PATCHERS = [
+    patch.dict(os.environ, {"PANEL_PASSWORD": "test-panel-password"}, clear=False),
     patch("dotenv.find_dotenv", return_value=".env.mock"),
     patch("dotenv.load_dotenv", return_value=True),
 ]

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -47,8 +47,7 @@ class TestReconnection(unittest.TestCase):
 
         self.assertEqual(reconnection._get_wan_proto(), "dhcp")
 
-    @patch("autodialer.network.wait_internet_recovery.sleep")
-    def test_apply_reconnection_calls_pppoe_method(self, mock_sleep: Any):
+    def test_apply_reconnection_calls_pppoe_method(self):
         router = Mock()
         router.make_pppoe_reconnection.return_value = True
 
@@ -101,10 +100,13 @@ class TestReconnection(unittest.TestCase):
         mock_exit.assert_not_called()
 
     @patch("builtins.exit", side_effect=SystemExit(1))
-    @patch("autodialer.network.wait_internet_recovery.sleep")
+    @patch.object(reconnection_module, "wait_internet_recovery")
     @patch.object(reconnection_module, "get_ip_address", return_value=None)
     def test_change_mode_exits_when_initial_ip_fetch_fails(
-        self, mock_get_ip_address: Any, mock_sleep: Any, mock_exit: Any
+        self,
+        mock_get_ip_address: Any,
+        _mock_wait_internet_recovery: Any,
+        mock_exit: Any,
     ):
         router = self._make_router()
         reconnection = reconnection_module.Reconnection(router)
@@ -118,7 +120,7 @@ class TestReconnection(unittest.TestCase):
         mock_exit.assert_called_once_with(1)
 
     @patch("builtins.exit")
-    @patch("autodialer.network.wait_internet_recovery.sleep")
+    @patch.object(reconnection_module, "wait_internet_recovery")
     @patch.object(
         reconnection_module,
         "get_ip_address",
@@ -127,7 +129,7 @@ class TestReconnection(unittest.TestCase):
     def test_change_mode_retries_until_ip_changes(
         self,
         mock_get_ip_address: Any,
-        mock_sleep: Any,
+        _mock_wait_internet_recovery: Any,
         mock_exit: Any,
     ):
         router = self._make_router()
@@ -140,7 +142,7 @@ class TestReconnection(unittest.TestCase):
         mock_exit.assert_not_called()
 
     @patch("builtins.exit", side_effect=SystemExit(1))
-    @patch("autodialer.network.wait_internet_recovery.sleep")
+    @patch.object(reconnection_module, "wait_internet_recovery")
     @patch.object(
         reconnection_module,
         "get_ip_address",
@@ -152,7 +154,10 @@ class TestReconnection(unittest.TestCase):
         ],
     )
     def test_change_mode_exits_after_exhausting_attempts(
-        self, mock_get_ip_address: Any, mock_sleep: Any, mock_exit: Any
+        self,
+        mock_get_ip_address: Any,
+        _mock_wait_internet_recovery: Any,
+        mock_exit: Any,
     ):
         router = self._make_router()
         reconnection = reconnection_module.Reconnection(router)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Env discovery now fails fast with a clear startup error when required env files are missing; logger startup moved earlier for clearer error reporting.
* **Bug Fixes**
  * Internet-recovery now creates and releases network resources per probe, returns only on success, and uses fewer default retry attempts.
* **Tests**
  * Test bootstrap forces a test panel password, robustly mocks env loading with cleanup, and updates reconnection tests to mock the wait mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->