### PR TITLE
fix(unittest, check_isp): Avoid network requesting in the mock, improve retry logic

### DIFF
--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -13,9 +13,10 @@ if env_file == "":
     exit(1)
 dotenv.load_dotenv(env_file)
 
-
+# For some routers, username is not required, so we can default to "admin".
 PANEL_USERNAME: str = os.getenv("PANEL_USERNAME") or "admin"
 
+# Password is required for all routers, so we will exit if it's not set.
 _PANEL_PASSWORD: str | None = os.getenv("PANEL_PASSWORD")
 if _PANEL_PASSWORD is None:
     logger.error("Error: PANEL_PASSWORD environment variable is not set.")

--- a/src/autodialer/network/check_isp.py
+++ b/src/autodialer/network/check_isp.py
@@ -1,6 +1,5 @@
 import logging
 import requests
-import time
 
 
 logger = logging.getLogger(__name__)
@@ -45,28 +44,24 @@ def check_isp(verbose: bool = False) -> str | None:
         return None
 
 
-def check_isp_with_retries(retries: int = 3, delay: int = 5) -> str | None:
+def check_isp_with_retries(retries: int = 3) -> str | None:
     """Check the ISP with retries if the initial check fails.
 
     Args:
         retries: The number of times to retry checking the ISP if it fails.
-        delay: The delay in seconds between retries.
 
     Returns:
         The ISP string if successful, or None if all retries fail.
     """
 
-    if retries <= 0 or delay <= 0:
-        logger.error(
-            "Invalid retries or delay parameters. Retries must be non-negative and delay must be a positive integer."
-        )
+    if retries <= 0:
+        logger.error("Invalid retries parameter. Retries must be a positive integer.")
         return None
 
     for _ in range(retries):
         isp = check_isp()
         if isp is not None:
             return isp
-        time.sleep(delay)
 
     logger.error("Failed to verify ISP after retries. Check your internet connection.")
     return None

--- a/src/autodialer/network/check_isp.py
+++ b/src/autodialer/network/check_isp.py
@@ -20,7 +20,7 @@ def check_isp(verbose: bool = False) -> str | None:
     """
     try:
         response = requests.get(
-            "https://ipinfo.io/json", proxies={"http": "", "https": ""}, timeout=4
+            "https://ipinfo.io/json", proxies={"http": "", "https": ""}, timeout=5
         )
         response.raise_for_status()
         data = response.json()
@@ -56,25 +56,17 @@ def check_isp_with_retries(retries: int = 3, delay: int = 5) -> str | None:
         The ISP string if successful, or None if all retries fail.
     """
 
-    if retries < 0 or delay <= 0:
+    if retries <= 0 or delay <= 0:
         logger.error(
             "Invalid retries or delay parameters. Retries must be non-negative and delay must be a positive integer."
         )
         return None
 
-    isp = check_isp()
-    if isp is not None:
-        return isp
-
-    if retries == 0:
-        logger.warning("ISP check failed. No retries left.")
-        return None
-
     for _ in range(retries):
-        time.sleep(delay)
         isp = check_isp()
         if isp is not None:
             return isp
+        time.sleep(delay)
 
     logger.error("Failed to verify ISP after retries. Check your internet connection.")
     return None

--- a/src/autodialer/network/check_isp.py
+++ b/src/autodialer/network/check_isp.py
@@ -54,10 +54,16 @@ def check_isp_with_retries(retries: int = 3) -> str | None:
         The ISP string if successful, or None if all retries fail.
     """
 
-    if retries <= 0:
+    if retries < 0 or retries > 100 or not isinstance(retries, int):
         logger.error("Invalid retries parameter. Retries must be a positive integer.")
         return None
 
+    # if retries == 0, we still want to perform one check.
+    isp = check_isp()
+    if isp is not None:
+        return isp
+
+    # Retry logic: if the initial check fails, retry up to `retries` times.
     for _ in range(retries):
         isp = check_isp()
         if isp is not None:

--- a/src/autodialer/network/check_isp.py
+++ b/src/autodialer/network/check_isp.py
@@ -55,15 +55,16 @@ def check_isp_with_retries(retries: int = 3, delay: int = 5) -> str | None:
     Returns:
         The ISP string if successful, or None if all retries fail.
     """
-    isp = check_isp()
-    if isp is not None:
-        return isp
 
     if retries < 0 or delay <= 0:
         logger.error(
             "Invalid retries or delay parameters. Retries must be non-negative and delay must be a positive integer."
         )
         return None
+
+    isp = check_isp()
+    if isp is not None:
+        return isp
 
     if retries == 0:
         logger.warning("ISP check failed. No retries left.")

--- a/tests/test_check_isp.py
+++ b/tests/test_check_isp.py
@@ -1,7 +1,7 @@
-import unittest
-from unittest.mock import Mock, patch
-from typing import Any
 import importlib
+import unittest
+from typing import Any
+from unittest.mock import Mock, patch
 
 import requests
 
@@ -60,10 +60,11 @@ class TestCheckIspWithRetries(unittest.TestCase):
         self.assertEqual(mock_check_isp.call_count, 3)
         self.assertEqual(mock_sleep.call_count, 2)
 
-    @patch.object(check_isp_module, "check_isp", return_value=None)
-    def test_invalid_retry_parameters_return_none(self, _mock_check_isp: Any):
+    @patch.object(check_isp_module, "check_isp")
+    def test_invalid_retry_parameters_return_none(self, mock_check_isp: Any):
         self.assertIsNone(check_isp_with_retries(retries=-1, delay=1))
         self.assertIsNone(check_isp_with_retries(retries=1, delay=0))
+        mock_check_isp.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_check_isp.py
+++ b/tests/test_check_isp.py
@@ -57,7 +57,7 @@ class TestCheckIspWithRetries(unittest.TestCase):
         result = check_isp_with_retries(retries=2, delay=1)
 
         self.assertIsNone(result)
-        self.assertEqual(mock_check_isp.call_count, 3)
+        self.assertEqual(mock_check_isp.call_count, 2)
         self.assertEqual(mock_sleep.call_count, 2)
 
     @patch.object(check_isp_module, "check_isp")

--- a/tests/test_check_isp.py
+++ b/tests/test_check_isp.py
@@ -47,17 +47,20 @@ class TestCheckIspWithRetries(unittest.TestCase):
         result = check_isp_with_retries(retries=3)
 
         self.assertEqual(result, "AS9999 Retry ISP")
+        self.assertEqual(mock_check_isp.call_count, 3)
 
     @patch.object(check_isp_module, "check_isp", return_value=None)
     def test_returns_none_after_all_retries(self, mock_check_isp: Any):
         result = check_isp_with_retries(retries=2)
 
         self.assertIsNone(result)
+        self.assertEqual(mock_check_isp.call_count, 3)
 
     @patch.object(check_isp_module, "check_isp")
     def test_invalid_retry_parameters_return_none(self, mock_check_isp: Any):
         self.assertIsNone(check_isp_with_retries(retries=-1))
-        self.assertIsNone(check_isp_with_retries(retries=0))
+        self.assertIsNone(check_isp_with_retries(retries=999))
+        self.assertIsNone(check_isp_with_retries(retries=2.5))  # type:ignore
         mock_check_isp.assert_not_called()
 
 

--- a/tests/test_check_isp.py
+++ b/tests/test_check_isp.py
@@ -60,7 +60,7 @@ class TestCheckIspWithRetries(unittest.TestCase):
     def test_invalid_retry_parameters_return_none(self, mock_check_isp: Any):
         self.assertIsNone(check_isp_with_retries(retries=-1))
         self.assertIsNone(check_isp_with_retries(retries=999))
-        self.assertIsNone(check_isp_with_retries(retries=2.5))  # type:ignore
+        self.assertIsNone(check_isp_with_retries(retries=2.5))  # type: ignore
         mock_check_isp.assert_not_called()
 
 

--- a/tests/test_check_isp.py
+++ b/tests/test_check_isp.py
@@ -40,23 +40,19 @@ class TestCheckIsp(unittest.TestCase):
 
 
 class TestCheckIspWithRetries(unittest.TestCase):
-    @patch.object(check_isp_module.time, "sleep")
     @patch.object(
         check_isp_module, "check_isp", side_effect=[None, None, "AS9999 Retry ISP"]
     )
-    def test_retries_until_success(self, mock_check_isp: Any, mock_sleep: Any):
+    def test_retries_until_success(self, mock_check_isp: Any):
         result = check_isp_with_retries(retries=3)
 
         self.assertEqual(result, "AS9999 Retry ISP")
-        self.assertEqual(mock_check_isp.call_count, 3)
 
-    @patch.object(check_isp_module.time, "sleep")
     @patch.object(check_isp_module, "check_isp", return_value=None)
-    def test_returns_none_after_all_retries(self, mock_check_isp: Any, mock_sleep: Any):
+    def test_returns_none_after_all_retries(self, mock_check_isp: Any):
         result = check_isp_with_retries(retries=2)
 
         self.assertIsNone(result)
-        self.assertEqual(mock_check_isp.call_count, 2)
 
     @patch.object(check_isp_module, "check_isp")
     def test_invalid_retry_parameters_return_none(self, mock_check_isp: Any):

--- a/tests/test_check_isp.py
+++ b/tests/test_check_isp.py
@@ -45,25 +45,23 @@ class TestCheckIspWithRetries(unittest.TestCase):
         check_isp_module, "check_isp", side_effect=[None, None, "AS9999 Retry ISP"]
     )
     def test_retries_until_success(self, mock_check_isp: Any, mock_sleep: Any):
-        result = check_isp_with_retries(retries=3, delay=1)
+        result = check_isp_with_retries(retries=3)
 
         self.assertEqual(result, "AS9999 Retry ISP")
         self.assertEqual(mock_check_isp.call_count, 3)
-        self.assertEqual(mock_sleep.call_count, 2)
 
     @patch.object(check_isp_module.time, "sleep")
     @patch.object(check_isp_module, "check_isp", return_value=None)
     def test_returns_none_after_all_retries(self, mock_check_isp: Any, mock_sleep: Any):
-        result = check_isp_with_retries(retries=2, delay=1)
+        result = check_isp_with_retries(retries=2)
 
         self.assertIsNone(result)
         self.assertEqual(mock_check_isp.call_count, 2)
-        self.assertEqual(mock_sleep.call_count, 2)
 
     @patch.object(check_isp_module, "check_isp")
     def test_invalid_retry_parameters_return_none(self, mock_check_isp: Any):
-        self.assertIsNone(check_isp_with_retries(retries=-1, delay=1))
-        self.assertIsNone(check_isp_with_retries(retries=1, delay=0))
+        self.assertIsNone(check_isp_with_retries(retries=-1))
+        self.assertIsNone(check_isp_with_retries(retries=0))
         mock_check_isp.assert_not_called()
 
 

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -120,6 +120,9 @@ class TestReconnection(unittest.TestCase):
         mock_exit.assert_called_once_with(1)
 
     @patch("builtins.exit")
+    @patch.object(
+        reconnection_module, "check_isp_with_retries", return_value="AS9999 Example ISP"
+    )
     @patch.object(reconnection_module, "wait_internet_recovery")
     @patch.object(
         reconnection_module,
@@ -130,6 +133,7 @@ class TestReconnection(unittest.TestCase):
         self,
         mock_get_ip_address: Any,
         _mock_wait_internet_recovery: Any,
+        mock_check_isp_with_retries: Any,
         mock_exit: Any,
     ):
         router = self._make_router()
@@ -139,6 +143,7 @@ class TestReconnection(unittest.TestCase):
 
         self.assertEqual(router.dhcp_renew.call_count, 2)
         self.assertEqual(mock_get_ip_address.call_count, 3)
+        mock_check_isp_with_retries.assert_called_once_with()
         mock_exit.assert_not_called()
 
     @patch("builtins.exit", side_effect=SystemExit(1))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced configuration validation for authentication settings — app now aborts immediately if a required credential is missing.
  * Network check behavior tightened: retry count is strictly validated, retries run without inter-attempt delays, and the network request timeout was slightly increased.

* **Tests**
  * Updated tests to reflect the new retry validation and retry/no-delay behavior and to assert network-check invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->