### PR TITLE
feat: implement environment variable handling and add unit tests for `parse_and_save_env_flags`

### DIFF
--- a/src/autodialer/config/__init__.py
+++ b/src/autodialer/config/__init__.py
@@ -1,4 +1,5 @@
 from .config import load_env_file
 from .config import parse_and_save_env_flags
+from .config import get_env_file_path
 
-__all__ = ["parse_and_save_env_flags", "load_env_file"]
+__all__ = ["parse_and_save_env_flags", "load_env_file", "get_env_file_path"]

--- a/src/autodialer/config/__init__.py
+++ b/src/autodialer/config/__init__.py
@@ -1,0 +1,4 @@
+from .config import load_env_file
+from .config import parse_and_save_env_flags
+
+__all__ = ["parse_and_save_env_flags", "load_env_file"]

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -1,28 +1,70 @@
 import os
-import dotenv  # type: ignore[import-not-found]
+import sys
+import dotenv
 import logging
+from pathlib import Path
+from collections import namedtuple
 
 logger = logging.getLogger(__name__)
 
 
-env_file = dotenv.find_dotenv()
-if env_file == "":
-    logger.error(
-        ".env file not found. Please create a .env file with appropriate values."
+def parse_and_save_env_flags():
+    """Extracts -e / --env flags, saves them to .env, and removes them from sys.argv"""
+
+    env_file_path = Path(".env")
+
+    # Create an empty .env file if it doesn't exist so python-dotenv doesn't complain
+    if not env_file_path.exists():
+        env_file_path.touch()
+
+    i = 1
+    while i < len(sys.argv):
+        if sys.argv[i] in ("-e", "--env"):
+            if i + 1 < len(sys.argv) and "=" in sys.argv[i + 1]:
+                key, value = sys.argv[i + 1].split("=", 1)
+
+                # Write the key-value pair to the .env file
+                dotenv.set_key(str(env_file_path), key, value)
+
+                # Update the current environment immediately
+                os.environ[key] = value
+
+                # Remove the parsed arguments from sys.argv
+                sys.argv.pop(i)
+                sys.argv.pop(i)
+            else:
+                logger.error(
+                    "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
+                )
+                sys.exit(1)
+        else:
+            i += 1
+
+
+def load_env_file():
+    env_file = dotenv.find_dotenv()
+    if env_file == "":
+        logger.error(
+            ".env file not found. Please create a .env file with appropriate values."
+        )
+        exit(1)
+    dotenv.load_dotenv(env_file)
+
+    # For some routers, username is not required, so we can default to "admin".
+    PANEL_USERNAME: str = os.getenv("PANEL_USERNAME") or "admin"
+
+    # Password is required for all routers, so we will exit if it's not set.
+    _PANEL_PASSWORD: str | None = os.getenv("PANEL_PASSWORD")
+    if _PANEL_PASSWORD is None:
+        logger.error("Error: PANEL_PASSWORD environment variable is not set.")
+        exit(1)
+
+    PANEL_PASSWORD: str = _PANEL_PASSWORD
+    PPPOE_USERNAME: str | None = os.getenv("PPPOE_USERNAME") or None
+    PPPOE_PASSWORD: str | None = os.getenv("PPPOE_PASSWORD") or None
+    ASN: str | None = os.getenv("ASN") or None
+    EnvVars = namedtuple(
+        "EnvVars",
+        ["PANEL_USERNAME", "PANEL_PASSWORD", "PPPOE_USERNAME", "PPPOE_PASSWORD", "ASN"],
     )
-    exit(1)
-dotenv.load_dotenv(env_file)
-
-# For some routers, username is not required, so we can default to "admin".
-PANEL_USERNAME: str = os.getenv("PANEL_USERNAME") or "admin"
-
-# Password is required for all routers, so we will exit if it's not set.
-_PANEL_PASSWORD: str | None = os.getenv("PANEL_PASSWORD")
-if _PANEL_PASSWORD is None:
-    logger.error("Error: PANEL_PASSWORD environment variable is not set.")
-    exit(1)
-
-PANEL_PASSWORD: str = _PANEL_PASSWORD
-PPPOE_USERNAME: str | None = os.getenv("PPPOE_USERNAME") or None
-PPPOE_PASSWORD: str | None = os.getenv("PPPOE_PASSWORD") or None
-ASN: str | None = os.getenv("ASN") or None
+    return EnvVars(PANEL_USERNAME, PANEL_PASSWORD, PPPOE_USERNAME, PPPOE_PASSWORD, ASN)

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -3,6 +3,7 @@ import sys
 import dotenv
 import logging
 from pathlib import Path
+import tempfile
 from collections import namedtuple
 
 logger = logging.getLogger(__name__)
@@ -10,17 +11,30 @@ logger = logging.getLogger(__name__)
 APP_NAME = "AutoDialer"
 
 
+def _safe_home_dir() -> Path:
+    try:
+        return Path.home()
+    except RuntimeError:
+        fallback_dir = (
+            os.getenv("HOME")
+            or os.getenv("USERPROFILE")
+            or os.getenv("TEMP")
+            or tempfile.gettempdir()
+        )
+        return Path(fallback_dir)
+
+
 def _default_config_dir() -> Path:
     if sys.platform.startswith("win"):
         base = os.getenv("APPDATA")
         if base:
             return Path(base) / APP_NAME
-        return Path.home() / "AppData" / "Roaming" / APP_NAME
+        return _safe_home_dir() / "AppData" / "Roaming" / APP_NAME
     elif sys.platform == "linux":
-        return Path.home() / ".config" / APP_NAME.lower()
+        return _safe_home_dir() / ".config" / APP_NAME.lower()
     elif sys.platform == "darwin":
-        return Path.home() / "Library" / "Application Support" / APP_NAME
-    return Path.home() / ".config" / APP_NAME.lower()
+        return _safe_home_dir() / "Library" / "Application Support" / APP_NAME
+    return _safe_home_dir() / ".config" / APP_NAME.lower()
 
 
 def get_env_file_path() -> Path:

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -48,7 +48,7 @@ def parse_and_save_env_flags():
 def load_env_file():
     env_file = get_env_file_path()
     if not env_file.exists():
-        logger.error(
+        logger.warning(
             f".env file not found at {env_file}. Please create it or set values via -e."
         )
         env_file.touch()  # Create an empty .env file to avoid issues with dotenv

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -8,10 +8,14 @@ from collections import namedtuple
 logger = logging.getLogger(__name__)
 
 
+def get_env_file_path():
+    return Path(__file__).resolve().parent.parent / ".env"
+
+
 def parse_and_save_env_flags():
     """Extracts -e / --env flags, saves them to .env, and removes them from sys.argv"""
 
-    env_file_path = Path(".env")
+    env_file_path = get_env_file_path()
 
     # Create an empty .env file if it doesn't exist so python-dotenv doesn't complain
     if not env_file_path.exists():
@@ -42,13 +46,13 @@ def parse_and_save_env_flags():
 
 
 def load_env_file():
-    env_file = dotenv.find_dotenv()
-    if env_file == "":
+    env_file = get_env_file_path()
+    if not env_file.exists():
         logger.error(
-            ".env file not found. Please create a .env file with appropriate values."
+            f".env file not found at {env_file}. Please create it or set values via -e."
         )
-        exit(1)
-    dotenv.load_dotenv(env_file)
+        sys.exit(1)
+    dotenv.load_dotenv(str(env_file))
 
     # For some routers, username is not required, so we can default to "admin".
     PANEL_USERNAME: str = os.getenv("PANEL_USERNAME") or "admin"
@@ -57,7 +61,7 @@ def load_env_file():
     _PANEL_PASSWORD: str | None = os.getenv("PANEL_PASSWORD")
     if _PANEL_PASSWORD is None:
         logger.error("Error: PANEL_PASSWORD environment variable is not set.")
-        exit(1)
+        sys.exit(1)
 
     PANEL_PASSWORD: str = _PANEL_PASSWORD
     PPPOE_USERNAME: str | None = os.getenv("PPPOE_USERNAME") or None

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -51,7 +51,7 @@ def load_env_file():
         logger.error(
             f".env file not found at {env_file}. Please create it or set values via -e."
         )
-        sys.exit(1)
+        env_file.touch()  # Create an empty .env file to avoid issues with dotenv
     dotenv.load_dotenv(str(env_file))
 
     # For some routers, username is not required, so we can default to "admin".

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -26,6 +26,11 @@ def parse_and_save_env_flags():
         if sys.argv[i] in ("-e", "--env"):
             if i + 1 < len(sys.argv) and "=" in sys.argv[i + 1]:
                 key, value = sys.argv[i + 1].split("=", 1)
+                if not value:
+                    logger.error(
+                        "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
+                    )
+                    sys.exit(1)
 
                 # Write the key-value pair to the .env file
                 dotenv.set_key(str(env_file_path), key, value)

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -7,9 +7,26 @@ from collections import namedtuple
 
 logger = logging.getLogger(__name__)
 
+APP_NAME = "AutoDialer"
 
-def get_env_file_path():
-    return Path(__file__).resolve().parent.parent / ".env"
+
+def _default_config_dir() -> Path:
+    if sys.platform.startswith("win"):
+        base = os.getenv("APPDATA")
+        if base:
+            return Path(base) / APP_NAME
+        return Path.home() / "AppData" / "Roaming" / APP_NAME
+    elif sys.platform == "linux":
+        return Path.home() / ".config" / APP_NAME.lower()
+    elif sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / APP_NAME
+    return Path.home() / ".config" / APP_NAME.lower()
+
+
+def get_env_file_path() -> Path:
+    config_dir = Path(os.getenv("AUTODIALER_CONFIG_DIR") or _default_config_dir())
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir / ".env"
 
 
 def parse_and_save_env_flags():

--- a/src/autodialer/get_devices.py
+++ b/src/autodialer/get_devices.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 from sys import argv
 from autodialer.routers import get_router
+from autodialer.config import parse_and_save_env_flags
 
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ def validate_args(args: list[str]) -> bool:
 
 def get_devices() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parse_and_save_env_flags()
     if not validate_args(argv):
         exit(1)
     router = get_router()

--- a/src/autodialer/get_devices.py
+++ b/src/autodialer/get_devices.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from pathlib import Path
 from sys import argv
 from autodialer.routers import get_router
@@ -42,11 +43,11 @@ def get_devices() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     parse_and_save_env_flags()
     if not validate_args(argv):
-        exit(1)
+        sys.exit(1)
     router = get_router()
     if router is None:
         logger.error("Unsupported or undetected router vendor.")
-        exit(1)
+        sys.exit(1)
     devices = router.get_connected_devices()
     print_devices_table(devices)
 

--- a/src/autodialer/network/get_gateway.py
+++ b/src/autodialer/network/get_gateway.py
@@ -4,6 +4,7 @@ import platform
 import socket
 import struct
 import subprocess
+import sys
 from collections.abc import Callable, Iterable
 from urllib.parse import quote
 
@@ -62,7 +63,7 @@ def _get_gateway_ip_unsupported() -> str:
         "Unsupported platform: %s. Cannot determine default gateway IP address.",
         platform.system(),
     )
-    exit(1)
+    sys.exit(1)
 
 
 def get_gateway_ip_on_windows() -> str:
@@ -75,7 +76,7 @@ def get_gateway_ip_on_windows() -> str:
         )
     except OSError as e:
         logger.error("Failed to execute 'route print -4': %s", e)
-        exit(1)
+        sys.exit(1)
 
     for line in result.stdout.splitlines():
         fields = line.split()
@@ -86,7 +87,7 @@ def get_gateway_ip_on_windows() -> str:
             if _is_ip_address(gateway):
                 return gateway
     logger.error("Default gateway not found in 'route print -4' output.")
-    exit(1)
+    sys.exit(1)
 
 
 def get_gateway_ip_on_linux() -> str:
@@ -121,7 +122,7 @@ def get_gateway_ip_on_linux() -> str:
         )
     except OSError as e:
         logger.error("Failed to execute 'ip -4 route show default': %s", e)
-        exit(1)
+        sys.exit(1)
 
     for line in result.stdout.splitlines():
         fields = line.split()
@@ -139,7 +140,7 @@ def get_gateway_ip_on_linux() -> str:
         if parsed_gateway is not None:
             return parsed_gateway
     logger.error("Default gateway not found in 'ip -4 route show default' output.")
-    exit(1)
+    sys.exit(1)
 
 
 def get_gateway_ip_on_unix() -> str:
@@ -152,7 +153,7 @@ def get_gateway_ip_on_unix() -> str:
         )
     except OSError as e:
         logger.error("Failed to execute 'route -n get default': %s", e)
-        exit(1)
+        sys.exit(1)
 
     if result is not None:
         for line in result.stdout.splitlines():
@@ -172,7 +173,7 @@ def get_gateway_ip_on_unix() -> str:
         )
     except OSError as e:
         logger.error("Failed to execute 'netstat -rn': %s", e)
-        exit(1)
+        sys.exit(1)
 
     for line in result.stdout.splitlines():
         fields = line.split()
@@ -189,7 +190,7 @@ def get_gateway_ip_on_unix() -> str:
     logger.error(
         "Default gateway not found in 'route -n get default' or 'netstat -rn' output."
     )
-    exit(1)
+    sys.exit(1)
 
 
 platform_system = platform.system()

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -11,6 +11,7 @@ from autodialer.network import (
     normalize_asn,
     try_connect,
 )
+from autodialer.config import parse_and_save_env_flags
 
 
 logger = logging.getLogger(__name__)
@@ -153,6 +154,8 @@ def print_usage():
         "  -f, --force       Force a reconnection regardless of current ASN.\n"
         "  -a, --asn <ASN>   Reconnect until connected to the specified target ASN. Requires an ASN argument, e.g. AS12345.\n"
         "  -c, --change      Reconnect until the public IP address changes.\n"
+        "\nEnvironment Overrides:\n"
+        "  -e, --env <KEY=VAL> Temporarily update or configure an environment variable.\n"
     )
 
 
@@ -176,6 +179,8 @@ def validate_args():
         "--asn",
         "-c",
         "--change",
+        "-e",
+        "--env",
     ):
         print_usage()
         exit(0) if command in ("-h", "--help") else exit(1)
@@ -207,6 +212,7 @@ def validate_args():
 
 def reconnection():
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parse_and_save_env_flags()
     validate_args()
     router = get_router()
     if router is None:

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -1,8 +1,8 @@
 import logging
+import sys
 from sys import argv
 from pathlib import Path
 from typing import Literal
-
 from autodialer.routers import RouterAPI, get_router
 from autodialer.network import (
     check_isp_with_retries,
@@ -43,18 +43,18 @@ class Reconnection:
 
         if proto is None:
             logger.error("Unable to determine current WAN protocol.")
-            exit(1)
+            sys.exit(1)
 
         match mode:
             case "force":
                 if not self._apply_reconnection(proto):
-                    exit(1)
+                    sys.exit(1)
 
                 if not try_connect(self.delay, self.max_attempts):
                     logger.error(
                         "Internet did not recover after forced reconnection. Exiting."
                     )
-                    exit(1)
+                    sys.exit(1)
 
                 isp = check_isp_with_retries()
                 ip = get_ip_address()
@@ -69,7 +69,7 @@ class Reconnection:
             case "change":
                 if (current_ip := get_ip_address()) is None:
                     logger.error("Unable to fetch current IP address. Exiting.")
-                    exit(1)
+                    sys.exit(1)
 
                 after_reconnection_ip: str | None = current_ip
                 attempts = 0
@@ -78,19 +78,19 @@ class Reconnection:
                     current_ip == after_reconnection_ip
                 ) and attempts < self.max_attempts:
                     if not self._apply_reconnection(proto):
-                        exit(1)
+                        sys.exit(1)
 
                     if not try_connect(self.delay, self.max_attempts):
                         logger.error(
                             "Internet did not recover after reconnection. Exiting.",
                         )
-                        exit(1)
+                        sys.exit(1)
 
                     if (after_reconnection_ip := get_ip_address()) is None:
                         logger.error(
                             "Unable to fetch IP address after reconnection. Exiting."
                         )
-                        exit(1)
+                        sys.exit(1)
                     attempts += 1
 
                 if current_ip != after_reconnection_ip:
@@ -105,22 +105,22 @@ class Reconnection:
                 logger.error(
                     "Failed to change IP address after %d attempts.", self.max_attempts
                 )
-                exit(1)
+                sys.exit(1)
 
             case "asn":
                 for _ in range(self.max_attempts):
                     if not self._apply_reconnection(proto):
-                        exit(1)
+                        sys.exit(1)
 
                     if not try_connect(self.delay, self.max_attempts):
                         logger.error(
                             "Internet did not recover after reconnection. Exiting."
                         )
-                        exit(1)
+                        sys.exit(1)
 
                     isp = check_isp_with_retries()
                     if isp is None:
-                        exit(1)
+                        sys.exit(1)
 
                     if is_target_asn(current_isp=isp, target_asn=asn):
                         return
@@ -128,7 +128,7 @@ class Reconnection:
                 logger.error(
                     "Reached maximum reconnection attempts without switching to the desired ASN."
                 )
-                exit(1)
+                sys.exit(1)
 
     def main(self) -> None:
         match argv[1]:
@@ -162,14 +162,14 @@ def print_usage():
 def validate_args():
     if len(argv) < 2:
         print_usage()
-        exit(1)
+        sys.exit(1)
 
     if len(argv) > 3:
         logger.error(
             "Too many arguments provided. Please check the usage instructions."
         )
         print_usage()
-        exit(1)
+        sys.exit(1)
 
     command = argv[1]
     if command not in (
@@ -183,20 +183,20 @@ def validate_args():
         "--env",
     ):
         print_usage()
-        exit(0) if command in ("-h", "--help") else exit(1)
+        exit(0) if command in ("-h", "--help") else sys.exit(1)
 
     if command in ("-a", "--asn"):
         if len(argv) < 3:
             logger.error(
                 "ASN parameter is required when using the -a or --asn flag. e.g. AS12345"
             )
-            exit(1)
+            sys.exit(1)
         if not normalize_asn(argv[2]):
             logger.error(
                 "Invalid ASN format: %s. ASN should be in the format 'AS12345' or '12345'.",
                 argv[2],
             )
-            exit(1)
+            sys.exit(1)
         if is_target_asn(current_isp=check_isp_with_retries(), target_asn=argv[2]):
             logger.info(
                 "Already connected to the target ASN %s. No reconnection needed.",
@@ -207,7 +207,7 @@ def validate_args():
         if len(argv) > 2:
             logger.error("Too many arguments provided for the selected mode.\n")
             print_usage()
-            exit(1)
+            sys.exit(1)
 
 
 def reconnection():
@@ -219,7 +219,7 @@ def reconnection():
         logger.error(
             "Unable to detect router vendor or no API implementation available. Exiting."
         )
-        exit(1)
+        sys.exit(1)
     rec = Reconnection(router)
     rec.main()
 

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -155,7 +155,7 @@ def print_usage():
         "  -a, --asn <ASN>   Reconnect until connected to the specified target ASN. Requires an ASN argument, e.g. AS12345.\n"
         "  -c, --change      Reconnect until the public IP address changes.\n"
         "\nEnvironment Overrides:\n"
-        "  -e, --env <KEY=VAL> Temporarily update or configure an environment variable.\n"
+        "  -e, --env <KEY=VAL> Update or configure an environment variable by writing it to .env.\n"
     )
 
 

--- a/src/autodialer/routers/asus/asus_api.py
+++ b/src/autodialer/routers/asus/asus_api.py
@@ -9,7 +9,11 @@ import requests
 
 from autodialer.routers.base_router_api import RouterAPI
 from autodialer.network.get_gateway import format_ip_for_url_host, get_gateway_ip
-from autodialer.config.config import PANEL_PASSWORD, PANEL_USERNAME
+from autodialer.config import load_env_file
+
+env_var = load_env_file()
+PANEL_PASSWORD: str = env_var.PANEL_PASSWORD
+PANEL_USERNAME: str = env_var.PANEL_USERNAME
 
 USER_AGENT = "AutoDialer"
 REQUEST_TIMEOUT = 5
@@ -28,20 +32,17 @@ class AsusAPI(RouterAPI):
     """Interact with ASUSWRT routers using the web API."""
 
     SUPPORTED_VENDORS = ("ASUS", "ASUS AiMesh")
-
-    router_ip: str
-    panel_username: str
-    panel_password: str
     base_url: str
-    token: str
-    verify_ssl: bool
 
     def __init__(self):
-        self.router_ip = get_gateway_ip()
-        self.panel_username = PANEL_USERNAME
-        self.panel_password = PANEL_PASSWORD
+        self.router_ip: str = get_gateway_ip()
+        self.panel_username: str = PANEL_USERNAME
+        self.panel_password: str = PANEL_PASSWORD
         self.session = requests.Session()
-        self.base_url, self.verify_ssl, self.token = self._login_router()
+        login_result = self._login_router()
+        self.base_url: str = login_result[0]
+        self.verify_ssl: bool = login_result[1]
+        self.token: str = login_result[2]
 
     def _candidate_base_urls(self) -> list[tuple[str, bool]]:
         router_host = format_ip_for_url_host(self.router_ip)

--- a/src/autodialer/routers/asus/asus_api.py
+++ b/src/autodialer/routers/asus/asus_api.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 import re
+import sys
 from typing import Any
 from urllib.parse import quote
 
@@ -275,7 +276,7 @@ class AsusAPI(RouterAPI):
                 return base_url, verify_ssl, token
 
         logger.error("Login failed.")
-        exit(1)
+        sys.exit(1)
 
     def _auth_headers(self) -> dict[str, str]:
         return {

--- a/src/autodialer/routers/get_router.py
+++ b/src/autodialer/routers/get_router.py
@@ -4,7 +4,6 @@ from importlib import import_module
 from inspect import getmembers, isclass
 from pathlib import Path
 from autodialer.routers.base_router_api import RouterAPI
-
 from autodialer.network.check_vendor import check_router_vendor
 
 

--- a/src/autodialer/routers/tplink/tplink_api.py
+++ b/src/autodialer/routers/tplink/tplink_api.py
@@ -5,7 +5,12 @@ from autodialer.routers.base_router_api import RouterAPI
 from autodialer.network.get_gateway import format_ip_for_url_host, get_gateway_ip
 from typing import Literal
 from urllib.parse import unquote
-from autodialer.config.config import PANEL_PASSWORD, PPPOE_USERNAME, PPPOE_PASSWORD
+from autodialer.config import load_env_file
+
+env_var = load_env_file()
+PANEL_PASSWORD: str = env_var.PANEL_PASSWORD
+PPPOE_USERNAME: str | None = env_var.PPPOE_USERNAME
+PPPOE_PASSWORD: str | None = env_var.PPPOE_PASSWORD
 
 logger = logging.getLogger(__name__)
 

--- a/src/autodialer/routers/tplink/tplink_api.py
+++ b/src/autodialer/routers/tplink/tplink_api.py
@@ -73,7 +73,9 @@ class TPLinkAPI(RouterAPI):
         else:
             logger.error("Login failed.")
             logger.debug(response)
-            exit(1)
+            import sys
+
+            sys.exit(1)
         return None
 
     def set_credentials(self) -> bool:

--- a/src/autodialer/routers/zte/zte_api.py
+++ b/src/autodialer/routers/zte/zte_api.py
@@ -8,7 +8,7 @@ import requests
 
 from autodialer.routers.base_router_api import RouterAPI
 from autodialer.network.get_gateway import get_gateway_ip, format_ip_for_url_host
-from autodialer.config.config import load_env_file
+from autodialer.config import load_env_file
 from autodialer.routers.zte.zte_encode import zte_security_encode
 
 logger = logging.getLogger(__name__)

--- a/src/autodialer/routers/zte/zte_api.py
+++ b/src/autodialer/routers/zte/zte_api.py
@@ -8,10 +8,16 @@ import requests
 
 from autodialer.routers.base_router_api import RouterAPI
 from autodialer.network.get_gateway import get_gateway_ip, format_ip_for_url_host
-from autodialer.config.config import PANEL_PASSWORD, PANEL_USERNAME
+from autodialer.config.config import load_env_file
 from autodialer.routers.zte.zte_encode import zte_security_encode
 
 logger = logging.getLogger(__name__)
+env_var = load_env_file()
+PANEL_PASSWORD: str = env_var.PANEL_PASSWORD
+PANEL_USERNAME: str = env_var.PANEL_USERNAME
+PPPOE_USERNAME: str | None = env_var.PPPOE_USERNAME
+PPPOE_PASSWORD: str | None = env_var.PPPOE_PASSWORD
+ASN: str | None = env_var.ASN
 
 
 class ZTEApi(RouterAPI):

--- a/tests/test_parse_save_env.py
+++ b/tests/test_parse_save_env.py
@@ -35,12 +35,16 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
             mock_environ.__setitem__.assert_any_call("TEST_KEY", "TEST_VALUE")
             mock_environ.__setitem__.assert_any_call("ANOTHER_KEY", "ANOTHER_VALUE")
 
+    @patch("autodialer.config.config.logger")
     @patch.object(sys, "argv", ["script.py", "-e"])
-    def test_parse_and_save_env_flags_no_env(self):
+    def test_parse_and_save_env_flags_no_env(self, mock_logger):
         # Simulate command-line arguments without env flags
         with self.assertRaises(SystemExit) as context:
             parse_and_save_env_flags()
         self.assertTrue(context.exception.code != 0)
+        mock_logger.error.assert_called_with(
+            "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
+        )
 
     @patch("autodialer.config.config.logger")
     def test_parse_and_save_env_flags_invalid_format(self, mock_logger):

--- a/tests/test_parse_save_env.py
+++ b/tests/test_parse_save_env.py
@@ -1,0 +1,90 @@
+import sys
+import unittest
+from unittest.mock import patch
+from autodialer.config import parse_and_save_env_flags
+
+
+class TestParseAndSaveEnvFlags(unittest.TestCase):
+    @patch("autodialer.config.config.dotenv.set_key")
+    @patch("autodialer.config.config.os.environ")
+    def test_parse_and_save_env_flags(self, mock_environ, mock_set_key):
+        # Simulate command-line arguments
+        test_args = [
+            "script.py",
+            "-e",
+            "TEST_KEY=TEST_VALUE",
+            "--env",
+            "ANOTHER_KEY=ANOTHER_VALUE",
+        ]
+        with patch("sys.argv", test_args):
+            parse_and_save_env_flags()
+
+            # Check if set_key was called correctly
+            mock_set_key.assert_any_call(".env", "TEST_KEY", "TEST_VALUE")
+            mock_set_key.assert_any_call(".env", "ANOTHER_KEY", "ANOTHER_VALUE")
+
+            # Check if environment variables were set
+            mock_environ.__setitem__.assert_any_call("TEST_KEY", "TEST_VALUE")
+            mock_environ.__setitem__.assert_any_call("ANOTHER_KEY", "ANOTHER_VALUE")
+
+    @patch.object(sys, "argv", ["script.py", "-e"])
+    def test_parse_and_save_env_flags_no_env(self):
+        # Simulate command-line arguments without env flags
+        with self.assertRaises(SystemExit) as context:
+            parse_and_save_env_flags()
+            self.assertTrue(context.exception.code != 0)
+
+    @patch("autodialer.config.config.logger")
+    def test_parse_and_save_env_flags_invalid_format(self, mock_logger):
+        # Simulate command-line arguments with invalid env format
+        test_args = ["script.py", "-e", "INVALID_FORMAT"]
+        # Ensure set_key is not called
+        with self.assertRaises(SystemExit) as context:
+            with patch("sys.argv", test_args):
+                parse_and_save_env_flags()
+                self.assertTrue(context.exception.code != 0)
+                mock_logger.error.assert_called_with("requires a KEY=VALUE argument")
+
+    @patch("sys.argv", ["script.py", "-e", "KEY=VALUE", "-a", "AS12345"])
+    @patch("autodialer.config.config.dotenv.set_key")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_parse_and_save_env_with_multiple_args_1(self, mock_set_key):
+        # Simulate command-line arguments with env flags and other flags
+        parse_and_save_env_flags()
+        self.assertEqual(sys.argv, ["script.py", "-a", "AS12345"])
+        mock_set_key.assert_any_call(".env", "KEY", "VALUE")
+
+    @patch(
+        "sys.argv",
+        [
+            "script.py",
+            "-a",
+            "AS12345",
+            "-e",
+            "KEY=VALUE",
+        ],
+    )
+    @patch("autodialer.config.config.dotenv.set_key")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_parse_and_save_env_with_multiple_args_2(self, mock_set_key):
+        # Simulate command-line arguments with env flags and other flags
+        parse_and_save_env_flags()
+        self.assertEqual(sys.argv, ["script.py", "-a", "AS12345"])
+        mock_set_key.assert_any_call(".env", "KEY", "VALUE")
+
+    @patch(
+        "sys.argv",
+        [
+            "script.py",
+            "-f",
+            "-e",
+            "KEY=VALUE",
+        ],
+    )
+    @patch("autodialer.config.config.dotenv.set_key")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_parse_and_save_env_with_multiple_args_3(self, mock_set_key):
+        # Simulate command-line arguments with env flags and other flags
+        parse_and_save_env_flags()
+        self.assertEqual(sys.argv, ["script.py", "-f"])
+        mock_set_key.assert_any_call(".env", "KEY", "VALUE")

--- a/tests/test_parse_save_env.py
+++ b/tests/test_parse_save_env.py
@@ -1,14 +1,18 @@
 import sys
 import unittest
 from unittest.mock import patch
-from autodialer.config import parse_and_save_env_flags
+from autodialer.config import parse_and_save_env_flags, get_env_file_path
 
 
 class TestParseAndSaveEnvFlags(unittest.TestCase):
     @patch("autodialer.config.config.dotenv.set_key")
     @patch("autodialer.config.config.os.environ")
-    def test_parse_and_save_env_flags(self, mock_environ, mock_set_key):
+    @patch("autodialer.config.config.Path")
+    def test_parse_and_save_env_with_e_flags(
+        self, mock_path, mock_environ, mock_set_key
+    ):
         # Simulate command-line arguments
+        mock_path.return_value.exists.return_value = True  # Simulate .env file exists
         test_args = [
             "script.py",
             "-e",
@@ -20,8 +24,12 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
             parse_and_save_env_flags()
 
             # Check if set_key was called correctly
-            mock_set_key.assert_any_call(".env", "TEST_KEY", "TEST_VALUE")
-            mock_set_key.assert_any_call(".env", "ANOTHER_KEY", "ANOTHER_VALUE")
+            mock_set_key.assert_any_call(
+                str(get_env_file_path()), "TEST_KEY", "TEST_VALUE"
+            )
+            mock_set_key.assert_any_call(
+                str(get_env_file_path()), "ANOTHER_KEY", "ANOTHER_VALUE"
+            )
 
             # Check if environment variables were set
             mock_environ.__setitem__.assert_any_call("TEST_KEY", "TEST_VALUE")
@@ -32,7 +40,7 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
         # Simulate command-line arguments without env flags
         with self.assertRaises(SystemExit) as context:
             parse_and_save_env_flags()
-            self.assertTrue(context.exception.code != 0)
+        self.assertTrue(context.exception.code != 0)
 
     @patch("autodialer.config.config.logger")
     def test_parse_and_save_env_flags_invalid_format(self, mock_logger):
@@ -42,17 +50,19 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
         with self.assertRaises(SystemExit) as context:
             with patch("sys.argv", test_args):
                 parse_and_save_env_flags()
-                self.assertTrue(context.exception.code != 0)
-                mock_logger.error.assert_called_with("requires a KEY=VALUE argument")
+        self.assertTrue(context.exception.code != 0)
+        mock_logger.error.assert_called_with(
+            "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
+        )
 
     @patch("sys.argv", ["script.py", "-e", "KEY=VALUE", "-a", "AS12345"])
     @patch("autodialer.config.config.dotenv.set_key")
     @patch.dict("os.environ", {}, clear=True)
-    def test_parse_and_save_env_with_multiple_args_1(self, mock_set_key):
+    def test_parse_and_save_env_with_multiple_valid_args_1(self, mock_set_key):
         # Simulate command-line arguments with env flags and other flags
         parse_and_save_env_flags()
         self.assertEqual(sys.argv, ["script.py", "-a", "AS12345"])
-        mock_set_key.assert_any_call(".env", "KEY", "VALUE")
+        mock_set_key.assert_any_call(str(get_env_file_path()), "KEY", "VALUE")
 
     @patch(
         "sys.argv",
@@ -66,11 +76,11 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
     )
     @patch("autodialer.config.config.dotenv.set_key")
     @patch.dict("os.environ", {}, clear=True)
-    def test_parse_and_save_env_with_multiple_args_2(self, mock_set_key):
+    def test_parse_and_save_env_with_multiple_valid_args_2(self, mock_set_key):
         # Simulate command-line arguments with env flags and other flags
         parse_and_save_env_flags()
         self.assertEqual(sys.argv, ["script.py", "-a", "AS12345"])
-        mock_set_key.assert_any_call(".env", "KEY", "VALUE")
+        mock_set_key.assert_any_call(str(get_env_file_path()), "KEY", "VALUE")
 
     @patch(
         "sys.argv",
@@ -83,8 +93,8 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
     )
     @patch("autodialer.config.config.dotenv.set_key")
     @patch.dict("os.environ", {}, clear=True)
-    def test_parse_and_save_env_with_multiple_args_3(self, mock_set_key):
+    def test_parse_and_save_env_with_multiple_valid_args_3(self, mock_set_key):
         # Simulate command-line arguments with env flags and other flags
         parse_and_save_env_flags()
         self.assertEqual(sys.argv, ["script.py", "-f"])
-        mock_set_key.assert_any_call(".env", "KEY", "VALUE")
+        mock_set_key.assert_any_call(str(get_env_file_path()), "KEY", "VALUE")

--- a/tests/test_parse_save_env.py
+++ b/tests/test_parse_save_env.py
@@ -37,7 +37,18 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
 
     @patch("autodialer.config.config.logger")
     @patch.object(sys, "argv", ["script.py", "-e"])
-    def test_parse_and_save_env_flags_no_env(self, mock_logger):
+    def test_parse_and_save_env_flags_no_env_1(self, mock_logger):
+        # Simulate command-line arguments without env flags
+        with self.assertRaises(SystemExit) as context:
+            parse_and_save_env_flags()
+        self.assertTrue(context.exception.code != 0)
+        mock_logger.error.assert_called_with(
+            "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
+        )
+
+    @patch("autodialer.config.config.logger")
+    @patch.object(sys, "argv", ["script.py", "-e", "PANEL_PASSWORD="])
+    def test_parse_and_save_env_flags_no_env_2(self, mock_logger):
         # Simulate command-line arguments without env flags
         with self.assertRaises(SystemExit) as context:
             parse_and_save_env_flags()

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -79,7 +79,7 @@ class TestReconnection(unittest.TestCase):
         )
         mock_exit.assert_not_called()
 
-    @patch("builtins.exit", side_effect=SystemExit(1))
+    @patch("sys.exit", side_effect=SystemExit(1))
     @patch.object(reconnection_module, "try_connect", return_value=False)
     @patch.object(reconnection_module, "get_ip_address", return_value=None)
     def test_change_mode_exits_when_initial_ip_fetch_fails(
@@ -99,7 +99,7 @@ class TestReconnection(unittest.TestCase):
         router.dhcp_renew.assert_not_called()
         mock_exit.assert_called_once_with(1)
 
-    @patch("builtins.exit")
+    @patch("sys.exit")
     @patch.object(
         reconnection_module, "check_isp_with_retries", return_value="AS9999 Example ISP"
     )
@@ -126,7 +126,7 @@ class TestReconnection(unittest.TestCase):
         mock_check_isp_with_retries.assert_called_once_with()
         mock_exit.assert_not_called()
 
-    @patch("builtins.exit", side_effect=SystemExit(1))
+    @patch("sys.exit", side_effect=SystemExit(1))
     @patch.object(reconnection_module, "try_connect", return_value=True)
     @patch.object(
         reconnection_module,


### PR DESCRIPTION
This PR implements the feature that enables users to pass environment variable like `PANEL_PASSWORD=123` in the CLI using `-e PANEL_PASSWORD=123` instead of manually creating a `.env` file, which is complicated and inconvenient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI env-override option (-e/--env KEY=VALUE) processed at startup, documented in help, and persisted to a per-user config file; overrides applied immediately.
  * Automatic router vendor discovery with dynamic selection of vendor-specific implementations.

* **Bug Fixes**
  * More consistent process termination on fatal errors (uses unified exit behavior).
  * Required panel credential validation enforced at startup.

* **Tests**
  * Added/expanded tests for env-override parsing, .env writes, CLI interactions, and exit behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->