### PR TITLE
Add argparse for better parsing arguments

### DIFF
--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -43,8 +43,8 @@ def get_env_file_path() -> Path:
     return config_dir / ".env"
 
 
-def parse_and_save_env_flags():
-    """Extracts -e / --env flags, saves them to .env, and removes them from sys.argv"""
+def parse_and_save_env_flags(env_args: list[str]):
+    """Saves passed KEY=VALUE strings to .env and the current environment."""
 
     env_file_path = get_env_file_path()
 
@@ -52,33 +52,25 @@ def parse_and_save_env_flags():
     if not env_file_path.exists():
         env_file_path.touch()
 
-    i = 1
-    while i < len(sys.argv):
-        if sys.argv[i] in ("-e", "--env"):
-            if i + 1 < len(sys.argv) and "=" in sys.argv[i + 1]:
-                key, value = sys.argv[i + 1].split("=", 1)
-                if not value:
-                    logger.error(
-                        "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
-                    )
-                    sys.exit(1)
+    for item in env_args:
+        if "=" not in item:
+            logger.error(
+                "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
+            )
+            sys.exit(1)
 
-                # Write the key-value pair to the .env file
-                dotenv.set_key(str(env_file_path), key, value)
+        key, value = item.split("=", 1)
+        if not value:
+            logger.error(
+                "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
+            )
+            sys.exit(1)
 
-                # Update the current environment immediately
-                os.environ[key] = value
+        # Write the key-value pair to the .env file
+        dotenv.set_key(str(env_file_path), key, value)
 
-                # Remove the parsed arguments from sys.argv
-                sys.argv.pop(i)
-                sys.argv.pop(i)
-            else:
-                logger.error(
-                    "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
-                )
-                sys.exit(1)
-        else:
-            i += 1
+        # Update the current environment immediately
+        os.environ[key] = value
 
 
 def load_env_file():

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -60,7 +60,7 @@ def parse_and_save_env_flags(env_args: list[str]):
             sys.exit(1)
 
         key, value = item.split("=", 1)
-        if not value:
+        if not value or not key:
             logger.error(
                 "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
             )

--- a/src/autodialer/get_devices.py
+++ b/src/autodialer/get_devices.py
@@ -40,7 +40,8 @@ def get_devices() -> None:
     )
     args = parser.parse_args()
     if args.env:
-        parse_and_save_env_flags()
+        parse_and_save_env_flags(args.env)
+
     router = get_router()
     if router is None:
         logger.error("Unsupported or undetected router vendor.")

--- a/src/autodialer/get_devices.py
+++ b/src/autodialer/get_devices.py
@@ -2,7 +2,6 @@ import logging
 import sys
 import argparse
 from autodialer.routers import get_router
-from autodialer.config import parse_and_save_env_flags
 
 
 logger = logging.getLogger(__name__)
@@ -40,6 +39,8 @@ def get_devices() -> None:
     )
     args = parser.parse_args()
     if args.env:
+        from autodialer.config import parse_and_save_env_flags
+
         parse_and_save_env_flags(args.env)
 
     router = get_router()

--- a/src/autodialer/get_devices.py
+++ b/src/autodialer/get_devices.py
@@ -1,7 +1,6 @@
 import logging
 import sys
-from pathlib import Path
-from sys import argv
+import argparse
 from autodialer.routers import get_router
 from autodialer.config import parse_and_save_env_flags
 
@@ -28,22 +27,20 @@ def print_devices_table(devices: list) -> None:
         )
 
 
-def validate_args(args: list[str]) -> bool:
-    if len(args) == 1:
-        return True
-    logger.error("Unknown argument: %s", args[1])
-    if Path(args[0]).suffix.lower() == ".py":
-        logger.error("Usage: python get_devices.py")
-    else:
-        logger.error("Usage: autodialer-devices")
-    return False
-
-
 def get_devices() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    parse_and_save_env_flags()
-    if not validate_args(argv):
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description="Get connected devices from the router."
+    )
+    parser.add_argument(
+        "-e",
+        "--env",
+        action="append",
+        help="Set environment variables (e.g., -e PANEL_PASSWORD=secret)",
+    )
+    args = parser.parse_args()
+    if args.env:
+        parse_and_save_env_flags()
     router = get_router()
     if router is None:
         logger.error("Unsupported or undetected router vendor.")

--- a/src/autodialer/network/is_target_asn.py
+++ b/src/autodialer/network/is_target_asn.py
@@ -19,10 +19,16 @@ def is_target_asn(current_isp: str | None, target_asn: str | None) -> bool:
 
 def normalize_asn(asn: str) -> str:
     raw_asn = asn.strip().upper()
-    if not raw_asn.startswith("AS"):
-        raw_asn = "AS" + raw_asn
+    if raw_asn.startswith("AS"):
+        digits = raw_asn[2:].strip()
+    else:
+        digits = raw_asn.strip()
 
-    digits = raw_asn[2:].strip()
-    if 1 <= len(digits) <= 10 and digits.isdigit():
-        return "AS" + digits
+    if digits.isdigit():
+        asn_num = int(digits)
+        # Valid 32-bit ASN range is 1 to 4294967295
+        # See https://www.iana.org/assignments/as-numbers/as-numbers.xhtml
+        if 1 <= asn_num <= 4294967295:
+            return f"AS{asn_num}"
+
     return ""

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -10,7 +10,6 @@ from autodialer.network import (
     normalize_asn,
     try_connect,
 )
-from autodialer.config import parse_and_save_env_flags
 
 
 logger = logging.getLogger(__name__)
@@ -184,8 +183,14 @@ def reconnection():
         help="Reconnect until the public IP address changes.",
     )
 
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
     args = parser.parse_args()
     if args.env:
+        from autodialer.config import parse_and_save_env_flags
+
         parse_and_save_env_flags(args.env)
 
     router = get_router()

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -198,6 +198,13 @@ def reconnection():
     if args.force:
         rec.main(mode="force")
     elif args.asn:
+        if is_target_asn(
+            current_isp=check_isp_with_retries(), target_asn=normalize_asn(args.asn)
+        ):
+            logger.info(
+                "Already connected to target ASN %s. No reconnection needed.", args.asn
+            )
+            sys.exit(0)
         rec.main(mode="asn", asn=normalize_asn(args.asn))
     elif args.change:
         rec.main(mode="change")

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -1,7 +1,6 @@
 import logging
 import sys
-from sys import argv
-from pathlib import Path
+import argparse
 from typing import Literal
 from autodialer.routers import RouterAPI, get_router
 from autodialer.network import (
@@ -130,90 +129,65 @@ class Reconnection:
                 )
                 sys.exit(1)
 
-    def main(self) -> None:
-        match argv[1]:
-            case "-f" | "--force":
+    def main(
+        self, mode: Literal["force", "asn", "change"], asn: str | None = None
+    ) -> None:
+        match mode:
+            case "force":
                 self.run_reconnection(mode="force", asn=None)
-            case "-a" | "--asn":
-                self.run_reconnection(mode="asn", asn=argv[2])
-            case "-c" | "--change":
+            case "asn":
+                self.run_reconnection(mode="asn", asn=asn)
+            case "change":
                 self.run_reconnection(mode="change", asn=None)
 
 
-def print_usage():
-    if Path(argv[0]).suffix.lower() == ".py":
-        logger.info(
-            "Usage: python reconnection.py [-f|--force] [-a|--asn <ASN>] [-c|--change] [-h|--help]"
+def validate_asn(value: str) -> str:
+    normalized = normalize_asn(value)
+    if not normalized:
+        raise argparse.ArgumentTypeError(
+            f"Invalid ASN format: '{value}'. Valid range is AS1 to AS4294967295."
         )
-    else:
-        logger.info(
-            "Usage: autodialer [-f|--force] [-a|--asn <ASN>] [-c|--change] [-h|--help]"
-        )
-    logger.info(
-        "\nReconnection modes:\n"
-        "  -f, --force       Force a reconnection regardless of current ASN.\n"
-        "  -a, --asn <ASN>   Reconnect until connected to the specified target ASN. Requires an ASN argument, e.g. AS12345.\n"
-        "  -c, --change      Reconnect until the public IP address changes.\n"
-        "\nEnvironment Overrides:\n"
-        "  -e, --env <KEY=VAL> Update or configure an environment variable by writing it to .env.\n"
-    )
-
-
-def validate_args():
-    if len(argv) < 2:
-        print_usage()
-        sys.exit(1)
-
-    if len(argv) > 3:
-        logger.error(
-            "Too many arguments provided. Please check the usage instructions."
-        )
-        print_usage()
-        sys.exit(1)
-
-    command = argv[1]
-    if command not in (
-        "-f",
-        "--force",
-        "-a",
-        "--asn",
-        "-c",
-        "--change",
-        "-e",
-        "--env",
-    ):
-        print_usage()
-        exit(0) if command in ("-h", "--help") else sys.exit(1)
-
-    if command in ("-a", "--asn"):
-        if len(argv) < 3:
-            logger.error(
-                "ASN parameter is required when using the -a or --asn flag. e.g. AS12345"
-            )
-            sys.exit(1)
-        if not normalize_asn(argv[2]):
-            logger.error(
-                "Invalid ASN format: %s. ASN should be in the format 'AS12345' or '12345'.",
-                argv[2],
-            )
-            sys.exit(1)
-        if is_target_asn(current_isp=check_isp_with_retries(), target_asn=argv[2]):
-            logger.info(
-                "Already connected to the target ASN %s. No reconnection needed.",
-                argv[2],
-            )
-            exit(0)
-    else:
-        if len(argv) > 2:
-            logger.error("Too many arguments provided for the selected mode.\n")
-            print_usage()
-            sys.exit(1)
+    return normalized
 
 
 def reconnection():
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    parse_and_save_env_flags()
-    validate_args()
+    parser = argparse.ArgumentParser(
+        description="Restart router WAN connection to obtain a new IP address or switch ASNs."
+    )
+    parser.add_argument(
+        "-e",
+        "--env",
+        metavar="<KEY=VAL>",
+        action="append",
+        help="Set environment variables (e.g., -e PANEL_PASSWORD=secret)",
+    )
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Force a reconnection regardless of current ASN.",
+    )
+    group.add_argument(
+        "-a",
+        "--asn",
+        metavar="<ASN>",
+        type=validate_asn,
+        help="Reconnect until connected to the specified target ASN.",
+    )
+    group.add_argument(
+        "-c",
+        "--change",
+        action="store_true",
+        help="Reconnect until the public IP address changes.",
+    )
+
+    args = parser.parse_args()
+    if args.env:
+        parse_and_save_env_flags()
+
     router = get_router()
     if router is None:
         logger.error(
@@ -221,7 +195,12 @@ def reconnection():
         )
         sys.exit(1)
     rec = Reconnection(router)
-    rec.main()
+    if args.force:
+        rec.main(mode="force")
+    elif args.asn:
+        rec.main(mode="asn", asn=normalize_asn(args.asn))
+    elif args.change:
+        rec.main(mode="change")
 
 
 if __name__ == "__main__":

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -186,7 +186,7 @@ def reconnection():
 
     args = parser.parse_args()
     if args.env:
-        parse_and_save_env_flags()
+        parse_and_save_env_flags(args.env)
 
     router = get_router()
     if router is None:

--- a/tests/test_parse_save_env.py
+++ b/tests/test_parse_save_env.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 from unittest.mock import patch
 from autodialer.config import parse_and_save_env_flags, get_env_file_path
@@ -11,47 +10,23 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
     def test_parse_and_save_env_with_e_flags(
         self, mock_path, mock_environ, mock_set_key
     ):
-        # Simulate command-line arguments
-        mock_path.return_value.exists.return_value = True  # Simulate .env file exists
-        test_args = [
-            "script.py",
-            "-e",
-            "TEST_KEY=TEST_VALUE",
-            "--env",
-            "ANOTHER_KEY=ANOTHER_VALUE",
-        ]
-        with patch("sys.argv", test_args):
-            parse_and_save_env_flags()
+        mock_path.return_value.exists.return_value = True
 
-            # Check if set_key was called correctly
-            mock_set_key.assert_any_call(
-                str(get_env_file_path()), "TEST_KEY", "TEST_VALUE"
-            )
-            mock_set_key.assert_any_call(
-                str(get_env_file_path()), "ANOTHER_KEY", "ANOTHER_VALUE"
-            )
+        env_args = ["TEST_KEY=TEST_VALUE", "ANOTHER_KEY=ANOTHER_VALUE"]
+        parse_and_save_env_flags(env_args)
 
-            # Check if environment variables were set
-            mock_environ.__setitem__.assert_any_call("TEST_KEY", "TEST_VALUE")
-            mock_environ.__setitem__.assert_any_call("ANOTHER_KEY", "ANOTHER_VALUE")
-
-    @patch("autodialer.config.config.logger")
-    @patch.object(sys, "argv", ["script.py", "-e"])
-    def test_parse_and_save_env_flags_no_env_1(self, mock_logger):
-        # Simulate command-line arguments without env flags
-        with self.assertRaises(SystemExit) as context:
-            parse_and_save_env_flags()
-        self.assertTrue(context.exception.code != 0)
-        mock_logger.error.assert_called_with(
-            "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
+        mock_set_key.assert_any_call(str(get_env_file_path()), "TEST_KEY", "TEST_VALUE")
+        mock_set_key.assert_any_call(
+            str(get_env_file_path()), "ANOTHER_KEY", "ANOTHER_VALUE"
         )
 
+        mock_environ.__setitem__.assert_any_call("TEST_KEY", "TEST_VALUE")
+        mock_environ.__setitem__.assert_any_call("ANOTHER_KEY", "ANOTHER_VALUE")
+
     @patch("autodialer.config.config.logger")
-    @patch.object(sys, "argv", ["script.py", "-e", "PANEL_PASSWORD="])
-    def test_parse_and_save_env_flags_no_env_2(self, mock_logger):
-        # Simulate command-line arguments without env flags
+    def test_parse_and_save_env_flags_no_env_value(self, mock_logger):
         with self.assertRaises(SystemExit) as context:
-            parse_and_save_env_flags()
+            parse_and_save_env_flags(["PANEL_PASSWORD="])
         self.assertTrue(context.exception.code != 0)
         mock_logger.error.assert_called_with(
             "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
@@ -59,57 +34,9 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
 
     @patch("autodialer.config.config.logger")
     def test_parse_and_save_env_flags_invalid_format(self, mock_logger):
-        # Simulate command-line arguments with invalid env format
-        test_args = ["script.py", "-e", "INVALID_FORMAT"]
-        # Ensure set_key is not called
         with self.assertRaises(SystemExit) as context:
-            with patch("sys.argv", test_args):
-                parse_and_save_env_flags()
+            parse_and_save_env_flags(["INVALID_FORMAT"])
         self.assertTrue(context.exception.code != 0)
         mock_logger.error.assert_called_with(
             "Error: -e/--env requires a KEY=VALUE argument (e.g., -e PANEL_PASSWORD=secret)."
         )
-
-    @patch("sys.argv", ["script.py", "-e", "KEY=VALUE", "-a", "AS12345"])
-    @patch("autodialer.config.config.dotenv.set_key")
-    @patch.dict("os.environ", {}, clear=True)
-    def test_parse_and_save_env_with_multiple_valid_args_1(self, mock_set_key):
-        # Simulate command-line arguments with env flags and other flags
-        parse_and_save_env_flags()
-        self.assertEqual(sys.argv, ["script.py", "-a", "AS12345"])
-        mock_set_key.assert_any_call(str(get_env_file_path()), "KEY", "VALUE")
-
-    @patch(
-        "sys.argv",
-        [
-            "script.py",
-            "-a",
-            "AS12345",
-            "-e",
-            "KEY=VALUE",
-        ],
-    )
-    @patch("autodialer.config.config.dotenv.set_key")
-    @patch.dict("os.environ", {}, clear=True)
-    def test_parse_and_save_env_with_multiple_valid_args_2(self, mock_set_key):
-        # Simulate command-line arguments with env flags and other flags
-        parse_and_save_env_flags()
-        self.assertEqual(sys.argv, ["script.py", "-a", "AS12345"])
-        mock_set_key.assert_any_call(str(get_env_file_path()), "KEY", "VALUE")
-
-    @patch(
-        "sys.argv",
-        [
-            "script.py",
-            "-f",
-            "-e",
-            "KEY=VALUE",
-        ],
-    )
-    @patch("autodialer.config.config.dotenv.set_key")
-    @patch.dict("os.environ", {}, clear=True)
-    def test_parse_and_save_env_with_multiple_valid_args_3(self, mock_set_key):
-        # Simulate command-line arguments with env flags and other flags
-        parse_and_save_env_flags()
-        self.assertEqual(sys.argv, ["script.py", "-f"])
-        mock_set_key.assert_any_call(str(get_env_file_path()), "KEY", "VALUE")

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -173,87 +173,79 @@ class TestReconnection(unittest.TestCase):
             with self.assertRaises(SystemExit) as context:
                 reconnection_module.reconnection()
 
-        self.assertEqual(context.exception.code, 0)
-
-
-class TestPrintUsage(unittest.TestCase):
-    @patch.object(reconnection_module, "argv", ["reconnection.py"])
-    @patch.object(reconnection_module, "logger")
-    def test_print_usage_for_python_script(self, mock_logger):
-        reconnection_module.print_usage()
-        mock_logger.info.assert_any_call(
-            "Usage: python reconnection.py [-f|--force] [-a|--asn <ASN>] [-c|--change] [-h|--help]"
-        )
-
-    @patch.object(reconnection_module, "argv", ["autodialer"])
-    @patch.object(reconnection_module, "logger")
-    def test_print_usage_for_executable(self, mock_logger):
-        reconnection_module.print_usage()
-        mock_logger.info.assert_any_call(
-            "Usage: autodialer [-f|--force] [-a|--asn <ASN>] [-c|--change] [-h|--help]"
-        )
+        self.assertEqual(context.exception.code, 2)
 
 
 class TestValidateArgs(unittest.TestCase):
-    @patch.object(reconnection_module, "argv", ["autodialer", "--help"])
+    @patch("sys.argv", ["autodialer", "--help"])
     def test_help_mode_exits_with_zero(self):
         with self.assertRaises(SystemExit) as context:
             reconnection_module.reconnection()
         self.assertEqual(context.exception.code, 0)
 
-    @patch.object(reconnection_module, "argv", ["autodialer", "--help"])
-    @patch.object(reconnection_module, "logger")
-    def test_help_mode_exits_with_info_message(self, mock_logger):
-        with self.assertRaises(SystemExit):
-            reconnection_module.reconnection()
-        self.assertIn("Reconnection modes", mock_logger.info.call_args[0][0])
+    @patch("sys.argv", ["autodialer", "-f", "--invalid"])
+    def test_invalid_argument_exits_with_error(self):
+        with patch("sys.stderr.write") as mock_stderr:
+            with self.assertRaises(SystemExit) as context:
+                reconnection_module.reconnection()
+            self.assertEqual(context.exception.code, 2)
+            self.assertTrue(
+                any(
+                    "unrecognized arguments" in call[0][0]
+                    for call in mock_stderr.call_args_list
+                )
+            )
 
-    @patch.object(reconnection_module, "argv", ["autodialer", "--invalid"])
+    @patch("sys.argv", ["autodialer", "--asn"])
+    def test_asn_argument_without_value_exits_with_error(self):
+        with patch("sys.stderr.write") as mock_stderr:
+            with self.assertRaises(SystemExit) as context:
+                reconnection_module.reconnection()
+            self.assertEqual(context.exception.code, 2)
+            self.assertTrue(
+                any(
+                    "expected one argument" in call[0][0]
+                    for call in mock_stderr.call_args_list
+                )
+            )
+
+    @patch("sys.argv", ["autodialer", "--force"])
+    @patch.object(reconnection_module, "get_router", return_value=None)
     @patch.object(reconnection_module, "logger")
-    def test_invalid_argument_exits_with_error(self, mock_logger):
+    def test_force_mode_without_router_exits_with_error(
+        self, mock_logger, mock_get_router
+    ):
         with self.assertRaises(SystemExit) as context:
             reconnection_module.reconnection()
-
         self.assertEqual(context.exception.code, 1)
-        self.assertIn("Reconnection modes", mock_logger.info.call_args[0][0])
+        self.assertIn(
+            "Unable to detect router vendor", mock_logger.error.call_args[0][0]
+        )
 
-    @patch.object(reconnection_module, "argv", ["autodialer", "--asn"])
-    @patch.object(reconnection_module, "logger")
-    def test_asn_argument_without_value_exits_with_error(self, mock_logger):
-        with self.assertRaises(SystemExit) as context:
-            reconnection_module.reconnection()
+    def test_asn_mode_with_invalid_asn_value_exits_with_error(self):
+        invalid_asns = [
+            "-1",
+            "f",
+            "9999999999999999999",
+            "AS0",
+            "AS-123",
+            "ASABC",
+            "trash",
+        ]
 
-        self.assertEqual(context.exception.code, 1)
-        self.assertIn("ASN parameter is required", mock_logger.error.call_args[0][0])
-
-    @patch.object(reconnection_module, "argv", ["autodialer", "--asn", "invalid_asn"])
-    @patch.object(reconnection_module, "logger")
-    def test_asn_argument_with_invalid_value_exits_with_error(self, mock_logger):
-        with self.assertRaises(SystemExit) as context:
-            reconnection_module.reconnection()
-
-        self.assertEqual(context.exception.code, 1)
-        self.assertIn("Invalid ASN format", mock_logger.error.call_args[0][0])
-
-    @patch.object(reconnection_module, "argv", ["autodialer", "--force", "extra_arg"])
-    @patch.object(reconnection_module, "logger")
-    def test_too_many_arguments_exits_with_error_1(self, mock_logger):
-        with self.assertRaises(SystemExit) as context:
-            reconnection_module.reconnection()
-
-        self.assertEqual(context.exception.code, 1)
-        self.assertIn("Too many arguments provided", mock_logger.error.call_args[0][0])
-
-    @patch.object(
-        reconnection_module, "argv", ["autodialer", "--asn", "AS12345", "extra_arg"]
-    )
-    @patch.object(reconnection_module, "logger")
-    def test_too_many_arguments_exits_with_error_2(self, mock_logger):
-        with self.assertRaises(SystemExit) as context:
-            reconnection_module.reconnection()
-
-        self.assertEqual(context.exception.code, 1)
-        self.assertIn("Too many arguments provided", mock_logger.error.call_args[0][0])
+        for invalid_asn in invalid_asns:
+            with self.subTest(asn=invalid_asn):
+                with patch("sys.argv", ["autodialer", "--asn", invalid_asn]):
+                    with patch("sys.stderr.write") as mock_stderr:
+                        with self.assertRaises(SystemExit) as context:
+                            reconnection_module.reconnection()
+                        self.assertEqual(context.exception.code, 2)
+                        self.assertTrue(
+                            any(
+                                "Invalid ASN format" in call[0][0]
+                                for call in mock_stderr.call_args_list
+                            )
+                        )
 
 
 if __name__ == "__main__":

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -156,6 +156,8 @@ class TestReconnection(unittest.TestCase):
         self.assertEqual(mock_get_ip_address.call_count, 4)
         mock_exit.assert_called_once_with(1)
 
+    @patch("sys.argv", ["autodialer", "--asn", "AS9929"])
+    @patch.object(reconnection_module, "get_router", return_value=Mock())
     @patch.object(reconnection_module, "is_target_asn", return_value=True)
     @patch.object(
         reconnection_module,
@@ -166,17 +168,16 @@ class TestReconnection(unittest.TestCase):
         self,
         _mock_check_isp: Any,
         _mock_is_target_asn: Any,
+        _mock_get_router: Any,
     ):
-        with patch.object(
-            reconnection_module, "argv", ["autodialer", "--asn", "AS9929"]
-        ):
-            with self.assertRaises(SystemExit) as context:
-                reconnection_module.reconnection()
 
-        self.assertEqual(context.exception.code, 2)
+        with self.assertRaises(SystemExit) as context:
+            reconnection_module.reconnection()
+
+        self.assertEqual(context.exception.code, 0)
 
 
-class TestValidateArgs(unittest.TestCase):
+class TestArgParse(unittest.TestCase):
     @patch("sys.argv", ["autodialer", "--help"])
     def test_help_mode_exits_with_zero(self):
         with self.assertRaises(SystemExit) as context:


### PR DESCRIPTION
Fixes #46 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stronger ASN validation enforcing 32-bit range and stricter formatting.
  * Reconnection CLI supports clear mutually-exclusive mode flags (--force, --asn, --change) and improved ASN validation/error messages.
  * Environment flag (-e/--env) accepts repeated uses, validates KEY=VALUE inputs, updates process environment immediately, and only processes env flags when provided.

* **Tests**
  * CLI and env-parsing tests refactored to align with argparse-driven behavior and direct env-flag invocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteFlowing1337/AutoDialer/pull/49)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->