### PR TITLE
test: fix regression in early return when already on targer asn

### DIFF
--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -134,6 +134,12 @@ class Reconnection:
             case "force":
                 self.run_reconnection(mode="force", asn=None, max_attempts=max_attempts)
             case "asn":
+                if is_target_asn(current_isp=check_isp_with_retries(), target_asn=asn):
+                    logger.info(
+                        "Already connected to target ASN %s. No reconnection needed.",
+                        asn,
+                    )
+                    return
                 self.run_reconnection(mode="asn", asn=asn, max_attempts=max_attempts)
             case "change":
                 self.run_reconnection(

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -182,7 +182,7 @@ class TestReconnection(unittest.TestCase):
 
         reconnection_module.reconnect(mode="asn", asn="AS9929")
 
-        router.get_wan_proto.assert_called_once()
+        router.get_wan_proto.assert_not_called()
 
     @patch.object(reconnection_module, "get_router", return_value=None)
     @patch.object(reconnection_module, "logger")

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -165,7 +165,6 @@ class TestReconnection(unittest.TestCase):
         mock_exit.assert_not_called()
 
     @patch.object(reconnection_module, "get_router")
-    @patch.object(reconnection_module, "is_target_asn", return_value=True)
     @patch.object(
         reconnection_module,
         "check_isp_with_retries",
@@ -174,7 +173,6 @@ class TestReconnection(unittest.TestCase):
     def test_asn_mode_exits_early_when_already_on_target_asn(
         self,
         _mock_check_isp: Any,
-        _mock_is_target_asn: Any,
         mock_get_router: Any,
     ):
         router = self._make_router()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the reconnection process to recognize when the device is already connected to the target ISP, preventing redundant reconnection attempts and improving overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->