### PR TITLE
typo: Rename to `Reconnector` class

### DIFF
--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -13,7 +13,7 @@ from autodialer.utils import is_target_asn
 logger = logging.getLogger(__name__)
 
 
-class Reconnection:
+class Reconnector:
     DEFAULT_MAX_ATTEMPTS = 5
 
     def __init__(self, router: RouterAPI, delay: int = 10):
@@ -157,5 +157,5 @@ def reconnect(
     router = get_router()
     if router is None:
         raise RuntimeError("Unable to detect router vendor or no API available.")
-    reconnection = Reconnection(router)
-    reconnection.main(mode, asn, max_attempts)
+    reconnector = Reconnector(router)
+    reconnector.main(mode, asn, max_attempts)

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -19,7 +19,7 @@ class TestReconnection(unittest.TestCase):
         router = Mock()
         router.get_wan_proto.return_value = "dhcp"
 
-        reconnection = reconnection_module.Reconnection(router)
+        reconnection = reconnection_module.Reconnector(router)
 
         self.assertEqual(reconnection._get_wan_proto(), "dhcp")
 
@@ -27,7 +27,7 @@ class TestReconnection(unittest.TestCase):
         router = Mock()
         router.make_pppoe_reconnection.return_value = True
 
-        reconnection = reconnection_module.Reconnection(router)
+        reconnection = reconnection_module.Reconnector(router)
 
         self.assertTrue(reconnection._apply_reconnection("pppoe"))
         router.make_pppoe_reconnection.assert_called_once_with()
@@ -44,7 +44,7 @@ class TestReconnection(unittest.TestCase):
         mock_exit: Any,
     ):
         router = self._make_router(proto="dhcp")
-        reconnection = reconnection_module.Reconnection(router, delay=7)
+        reconnection = reconnection_module.Reconnector(router, delay=7)
 
         events: list[str] = []
         isp_values = iter(["AS111 Example ISP", "AS222 Target ISP"])
@@ -88,7 +88,7 @@ class TestReconnection(unittest.TestCase):
         mock_exit: Any,
     ):
         router = self._make_router()
-        reconnection = reconnection_module.Reconnection(router)
+        reconnection = reconnection_module.Reconnector(router)
 
         with self.assertRaises(RuntimeError) as context:
             reconnection.run_reconnection(mode="change", asn=None)
@@ -118,7 +118,7 @@ class TestReconnection(unittest.TestCase):
         mock_exit: Any,
     ):
         router = self._make_router()
-        reconnection = reconnection_module.Reconnection(router)
+        reconnection = reconnection_module.Reconnector(router)
 
         reconnection.run_reconnection(mode="change", asn=None)
 
@@ -152,7 +152,7 @@ class TestReconnection(unittest.TestCase):
         mock_exit: Any,
     ):
         router = self._make_router()
-        reconnection = reconnection_module.Reconnection(router)
+        reconnection = reconnection_module.Reconnector(router)
 
         with self.assertRaises(RuntimeError) as context:
             reconnection.run_reconnection(mode="change", asn=None, max_attempts=3)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal class naming for improved code consistency and maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->