### PR TITLE
Add `-v` flags

### DIFF
--- a/src/autodialer/cli.py
+++ b/src/autodialer/cli.py
@@ -23,7 +23,7 @@ def main():
         "-v",
         "--version",
         action="version",
-        version=__version__,
+        version=f"AutoDialer {__version__}",
         help="Show the current version of AutoDialer",
     )
 

--- a/src/autodialer/cli.py
+++ b/src/autodialer/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 
+from autodialer import __version__
 from autodialer.utils import validate_asn
 
 
@@ -16,6 +17,14 @@ def main():
         action="append",
         metavar="<KEY=VAL>",
         help="Set environment variables (e.g., -e PANEL_PASSWORD=secret)",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=__version__,
+        help="Show the current version of AutoDialer",
     )
 
     parser.add_argument(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version/-v` command-line option to display the current AutoDialer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->