### PR TITLE
Add `time.sleep()` between getting ISP retries

### DIFF
--- a/src/autodialer/network/get_isp.py
+++ b/src/autodialer/network/get_isp.py
@@ -51,7 +51,7 @@ def check_isp(verbose: bool = False) -> str | None:
 
 
 def check_isp_with_retries(
-    retries: int = MAX_ISP_RETRIES, delay: int = ISP_RETRY_DELAY
+    retries: int = ISP_RETRIES, delay: int = ISP_RETRY_DELAY
 ) -> str | None:
     """Check the ISP with retries if the initial check fails.
 

--- a/src/autodialer/network/get_isp.py
+++ b/src/autodialer/network/get_isp.py
@@ -65,7 +65,8 @@ def check_isp_with_retries(
 
     if not isinstance(retries, int) or retries < 0 or retries > MAX_ISP_RETRIES:
         logger.error(
-            "Invalid retries parameter. Retries must be a non-negative number."
+            "Invalid retries parameter. Retries must be an integer between 0 and %d.",
+            MAX_ISP_RETRIES,
         )
         return None
 

--- a/src/autodialer/network/get_isp.py
+++ b/src/autodialer/network/get_isp.py
@@ -51,7 +51,7 @@ def check_isp(verbose: bool = False) -> str | None:
 
 
 def check_isp_with_retries(
-    retries: int = ISP_RETRIES, delay: int = ISP_RETRY_DELAY
+    retries: int = ISP_RETRIES, delay: int | float = ISP_RETRY_DELAY
 ) -> str | None:
     """Check the ISP with retries if the initial check fails.
 
@@ -65,12 +65,12 @@ def check_isp_with_retries(
 
     if not isinstance(retries, int) or retries < 0 or retries > MAX_ISP_RETRIES:
         logger.error(
-            "Invalid retries parameter. Retries must be a non-negative integer."
+            "Invalid retries parameter. Retries must be a non-negative number."
         )
         return None
 
-    if not isinstance(delay, int) or delay < 0:
-        logger.error("Invalid delay parameter. Delay must be a non-negative integer.")
+    if not isinstance(delay, (int, float)) or delay < 0:
+        logger.error("Invalid delay parameter. Delay must be a non-negative number.")
         return None
 
     for i in range(retries + 1):

--- a/src/autodialer/network/get_isp.py
+++ b/src/autodialer/network/get_isp.py
@@ -64,11 +64,13 @@ def check_isp_with_retries(
     """
 
     if retries < 0 or retries > MAX_ISP_RETRIES or not isinstance(retries, int):
-        logger.error("Invalid retries parameter. Retries must be a positive integer.")
+        logger.error(
+            "Invalid retries parameter. Retries must be a non-negative integer."
+        )
         return None
 
     if delay < 0 or not isinstance(delay, int):
-        logger.error("Invalid delay parameter. Delay must be a positive integer.")
+        logger.error("Invalid delay parameter. Delay must be a non-negative integer.")
         return None
 
     isp = check_isp()

--- a/src/autodialer/network/get_isp.py
+++ b/src/autodialer/network/get_isp.py
@@ -1,6 +1,12 @@
 import logging
+import time
 
 logger = logging.getLogger(__name__)
+
+GET_ISP_SOURCE_URL = "https://ipinfo.io/json"
+ISP_RETRIES = 3
+ISP_RETRY_DELAY = 5  # seconds
+MAX_ISP_RETRIES = 100
 
 
 def check_isp(verbose: bool = False) -> str | None:
@@ -19,7 +25,7 @@ def check_isp(verbose: bool = False) -> str | None:
 
     try:
         response = requests.get(
-            "https://ipinfo.io/json", proxies={"http": "", "https": ""}, timeout=5
+            GET_ISP_SOURCE_URL, proxies={"http": "", "https": ""}, timeout=5
         )
         response.raise_for_status()
         data = response.json()
@@ -44,18 +50,25 @@ def check_isp(verbose: bool = False) -> str | None:
         return None
 
 
-def check_isp_with_retries(retries: int = 3) -> str | None:
+def check_isp_with_retries(
+    retries: int = MAX_ISP_RETRIES, delay: int = ISP_RETRY_DELAY
+) -> str | None:
     """Check the ISP with retries if the initial check fails.
 
     Args:
         retries: The number of times to retry checking the ISP if it fails.
+        delay: The delay in seconds between retries.
 
     Returns:
         The ISP string if successful, or None if all retries fail.
     """
 
-    if retries < 0 or retries > 100 or not isinstance(retries, int):
+    if retries < 0 or retries > MAX_ISP_RETRIES or not isinstance(retries, int):
         logger.error("Invalid retries parameter. Retries must be a positive integer.")
+        return None
+
+    if delay < 0 or not isinstance(delay, int):
+        logger.error("Invalid delay parameter. Delay must be a positive integer.")
         return None
 
     isp = check_isp()
@@ -67,6 +80,7 @@ def check_isp_with_retries(retries: int = 3) -> str | None:
         isp = check_isp()
         if isp is not None:
             return isp
+        time.sleep(delay)
 
     logger.error("Failed to verify ISP after retries. Check your internet connection.")
     return None

--- a/src/autodialer/network/get_isp.py
+++ b/src/autodialer/network/get_isp.py
@@ -63,26 +63,22 @@ def check_isp_with_retries(
         The ISP string if successful, or None if all retries fail.
     """
 
-    if retries < 0 or retries > MAX_ISP_RETRIES or not isinstance(retries, int):
+    if not isinstance(retries, int) or retries < 0 or retries > MAX_ISP_RETRIES:
         logger.error(
             "Invalid retries parameter. Retries must be a non-negative integer."
         )
         return None
 
-    if delay < 0 or not isinstance(delay, int):
+    if not isinstance(delay, int) or delay < 0:
         logger.error("Invalid delay parameter. Delay must be a non-negative integer.")
         return None
 
-    isp = check_isp()
-    if isp is not None:
-        return isp
-
-    # Retry logic: if the initial check fails, retry up to `retries` times.
-    for _ in range(retries):
+    for i in range(retries + 1):
         isp = check_isp()
         if isp is not None:
             return isp
-        time.sleep(delay)
+        if i < retries:
+            time.sleep(delay)
 
     logger.error("Failed to verify ISP after retries. Check your internet connection.")
     return None

--- a/tests/test_get_isp.py
+++ b/tests/test_get_isp.py
@@ -43,18 +43,22 @@ class TestCheckIspWithRetries(unittest.TestCase):
     @patch.object(
         check_isp_module, "check_isp", side_effect=[None, None, "AS9999 Retry ISP"]
     )
-    def test_retries_until_success(self, mock_check_isp: Any):
+    @patch("time.sleep", return_value=None)
+    def test_retries_until_success(self, mock_sleep: Any, mock_check_isp: Any):
         result = check_isp_with_retries(retries=3)
 
         self.assertEqual(result, "AS9999 Retry ISP")
         self.assertEqual(mock_check_isp.call_count, 3)
+        mock_sleep.assert_called()
 
     @patch.object(check_isp_module, "check_isp", return_value=None)
-    def test_returns_none_after_all_retries(self, mock_check_isp: Any):
+    @patch("time.sleep", return_value=None)
+    def test_returns_none_after_all_retries(self, mock_sleep: Any, mock_check_isp: Any):
         result = check_isp_with_retries(retries=2)
 
         self.assertIsNone(result)
         self.assertEqual(mock_check_isp.call_count, 3)
+        mock_sleep.assert_called()
 
     @patch.object(check_isp_module, "check_isp")
     def test_invalid_retry_parameters_return_none(self, mock_check_isp: Any):

--- a/tests/test_get_isp.py
+++ b/tests/test_get_isp.py
@@ -70,16 +70,16 @@ class TestCheckIspWithRetries(unittest.TestCase):
     @patch.object(check_isp_module, "check_isp")
     def test_invalid_delay_parameter_return_none(self, mock_check_isp: Any):
         self.assertIsNone(check_isp_with_retries(delay=-1))
-        self.assertIsNone(check_isp_with_retries(delay=2.5))  # type: ignore
+        self.assertIsNone(check_isp_with_retries(delay="invalid"))  # type: ignore
         self.assertIsNone(check_isp_with_retries(retries=2, delay=-5))
         mock_check_isp.assert_not_called()
 
     @patch.object(check_isp_module, "check_isp", return_value=None)
     @patch("time.sleep", return_value=None)
     def test_delay_between_retries(self, mock_sleep: Any, mock_check_isp: Any):
-        check_isp_with_retries(retries=2, delay=10)
+        check_isp_with_retries(retries=2, delay=10.5)
         self.assertEqual(mock_sleep.call_count, 2)
-        mock_sleep.assert_called_with(10)
+        mock_sleep.assert_called_with(10.5)
 
     @patch.object(check_isp_module, "check_isp", return_value="AS5678 Success ISP")
     @patch("time.sleep", return_value=None)

--- a/tests/test_get_isp.py
+++ b/tests/test_get_isp.py
@@ -78,8 +78,38 @@ class TestCheckIspWithRetries(unittest.TestCase):
     @patch("time.sleep", return_value=None)
     def test_delay_between_retries(self, mock_sleep: Any, mock_check_isp: Any):
         check_isp_with_retries(retries=2, delay=10)
-        self.assertEqual(mock_check_isp.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
         mock_sleep.assert_called_with(10)
+
+    @patch.object(check_isp_module, "check_isp", return_value="AS5678 Success ISP")
+    @patch("time.sleep", return_value=None)
+    def test_no_delay_after_success(self, mock_sleep: Any, mock_check_isp: Any):
+        result = check_isp_with_retries(retries=3, delay=10)
+        self.assertEqual(result, "AS5678 Success ISP")
+        self.assertEqual(mock_sleep.call_count, 0)
+
+    @patch.object(
+        check_isp_module, "check_isp", side_effect=[None, "AS5678 Success ISP"]
+    )
+    @patch("time.sleep", return_value=None)
+    def test_no_delay_after_success_on_retry(
+        self, mock_sleep: Any, mock_check_isp: Any
+    ):
+        result = check_isp_with_retries(retries=3, delay=10)
+        self.assertEqual(result, "AS5678 Success ISP")
+        self.assertEqual(mock_sleep.call_count, 1)
+
+    @patch.object(check_isp_module, "check_isp", return_value=None)
+    @patch("time.sleep", return_value=None)
+    def test_no_delay_on_initial_retry(self, mock_sleep: Any, mock_check_isp: Any):
+        check_isp_with_retries(retries=0, delay=10)
+        mock_sleep.assert_not_called()
+
+    @patch.object(check_isp_module, "check_isp", return_value=None)
+    @patch("time.sleep", return_value=None)
+    def test_no_delay_after_final_retry(self, mock_sleep: Any, mock_check_isp: Any):
+        check_isp_with_retries(retries=2, delay=10)
+        self.assertEqual(mock_sleep.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_get_isp.py
+++ b/tests/test_get_isp.py
@@ -67,6 +67,20 @@ class TestCheckIspWithRetries(unittest.TestCase):
         self.assertIsNone(check_isp_with_retries(retries=2.5))  # type: ignore
         mock_check_isp.assert_not_called()
 
+    @patch.object(check_isp_module, "check_isp")
+    def test_invalid_delay_parameter_return_none(self, mock_check_isp: Any):
+        self.assertIsNone(check_isp_with_retries(delay=-1))
+        self.assertIsNone(check_isp_with_retries(delay=2.5))  # type: ignore
+        self.assertIsNone(check_isp_with_retries(retries=2, delay=-5))
+        mock_check_isp.assert_not_called()
+
+    @patch.object(check_isp_module, "check_isp", return_value=None)
+    @patch("time.sleep", return_value=None)
+    def test_delay_between_retries(self, mock_sleep: Any, mock_check_isp: Any):
+        check_isp_with_retries(retries=2, delay=10)
+        self.assertEqual(mock_check_isp.call_count, 3)
+        mock_sleep.assert_called_with(10)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * ISP detection now includes configurable retry delays for improved reliability during network operations.
  * Enhanced validation and error handling when connection attempts fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->