### PR TITLE
Enable `--env` flag being used individually

### DIFF
--- a/src/autodialer/cli.py
+++ b/src/autodialer/cli.py
@@ -37,7 +37,8 @@ def main():
         help="Number of reconnection attempts before giving up (default: 5)",
     )
 
-    group = parser.add_mutually_exclusive_group(required=True)
+    # Remove required=True because `-e` can be used individually
+    group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "-f",
         "--force",
@@ -73,7 +74,10 @@ def main():
     if args.env:
         from autodialer.config import parse_and_save_env_flags
 
-        parse_and_save_env_flags(args.env)
+        if not parse_and_save_env_flags(args.env):
+            sys.exit(1)
+        print("Environment variables updated successfully.")
+        return
 
     if args.devices:
         from autodialer.get_devices import print_devices_table

--- a/src/autodialer/cli.py
+++ b/src/autodialer/cli.py
@@ -71,13 +71,18 @@ def main():
         return
 
     args = parser.parse_args()
+    if not (args.env or args.devices or args.force or args.asn or args.change):
+        parser.error(
+            "At least one of --env, --force, --asn, --change, or --devices "
+            "must be specified."
+        )
+
     if args.env:
         from autodialer.config import parse_and_save_env_flags
 
         if not parse_and_save_env_flags(args.env):
             sys.exit(1)
         print("Environment variables updated successfully.")
-        return
 
     if args.devices:
         from autodialer.get_devices import print_devices_table

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -44,7 +44,7 @@ def get_env_file_path() -> Path:
     return config_dir / ".env"
 
 
-def parse_and_save_env_flags(env_args: list[str]):
+def parse_and_save_env_flags(env_args: list[str]) -> bool:
     """Saves passed KEY=VALUE strings to .env and the current environment."""
 
     env_file_path = get_env_file_path()
@@ -59,7 +59,7 @@ def parse_and_save_env_flags(env_args: list[str]):
                 "Error: -e/--env requires a KEY=VALUE argument "
                 "(e.g., -e PANEL_PASSWORD=secret)."
             )
-            sys.exit(1)
+            return False
 
         key, value = item.split("=", 1)
         if not value or not key:
@@ -67,13 +67,14 @@ def parse_and_save_env_flags(env_args: list[str]):
                 "Error: -e/--env requires a KEY=VALUE argument "
                 "(e.g., -e PANEL_PASSWORD=secret)."
             )
-            sys.exit(1)
+            return False
 
         # Write the key-value pair to the .env file
         dotenv.set_key(str(env_file_path), key, value)
 
         # Update the current environment immediately
         os.environ[key] = value
+    return True
 
 
 def load_env_file():

--- a/src/autodialer/config/config.py
+++ b/src/autodialer/config/config.py
@@ -53,6 +53,7 @@ def parse_and_save_env_flags(env_args: list[str]) -> bool:
     if not env_file_path.exists():
         env_file_path.touch()
 
+    parsed_pair = []
     for item in env_args:
         if "=" not in item:
             logger.error(
@@ -69,11 +70,15 @@ def parse_and_save_env_flags(env_args: list[str]) -> bool:
             )
             return False
 
+        parsed_pair.append((key, value))
+
+    for key, value in parsed_pair:
         # Write the key-value pair to the .env file
         dotenv.set_key(str(env_file_path), key, value)
 
         # Update the current environment immediately
         os.environ[key] = value
+
     return True
 
 

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -75,3 +75,11 @@ class TestArgParse(unittest.TestCase):
                     for call in mock_stderr.call_args_list
                 )
             )
+
+    @patch("sys.argv", ["autodialer", "-e", "password=123", "-f"])
+    @patch("autodialer.reconnection.reconnect", return_value=None)
+    @patch("autodialer.config.config.os.environ")
+    def test_multiple_flags_parse_no_early_return(self, mock_environ, mock_reconnect):
+        cli_module.main()
+        mock_environ.__setitem__.assert_any_call("password", "123")
+        mock_reconnect.assert_called_once_with(mode="force", max_attempts=5)

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -77,9 +77,13 @@ class TestArgParse(unittest.TestCase):
             )
 
     @patch("sys.argv", ["autodialer", "-e", "password=123", "-f"])
+    @patch("autodialer.config.config.Path")
+    @patch("autodialer.config.config.dotenv.set_key")
     @patch("autodialer.reconnection.reconnect", return_value=None)
     @patch("autodialer.config.config.os.environ")
-    def test_multiple_flags_parse_no_early_return(self, mock_environ, mock_reconnect):
+    def test_multiple_flags_parse_no_early_return(
+        self, mock_environ, mock_reconnect, mock_set_key, mock_path
+    ):
         cli_module.main()
         mock_environ.__setitem__.assert_any_call("password", "123")
         mock_reconnect.assert_called_once_with(mode="force", max_attempts=5)

--- a/tests/test_parse_save_env.py
+++ b/tests/test_parse_save_env.py
@@ -39,3 +39,16 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
             "Error: -e/--env requires a KEY=VALUE argument "
             "(e.g., -e PANEL_PASSWORD=secret)."
         )
+
+    @patch("autodialer.config.config.os.environ")
+    def test_only_save_env_var_when_all_args_valid(self, mock_environ):
+        env_flags = ["password=123", "invalid"]
+        self.assertEqual(parse_and_save_env_flags(env_flags), False)
+        mock_environ.assert_not_called()
+
+    @patch("autodialer.config.config.os.environ")
+    def test_only_save_env_var_when_all_args_valid_2(self, mock_environ):
+        env_flags = ["password=123", "username=123"]
+        self.assertEqual(parse_and_save_env_flags(env_flags), True)
+        mock_environ.__setitem__.assert_any_call("password", "123")
+        mock_environ.__setitem__.assert_any_call("username", "123")

--- a/tests/test_parse_save_env.py
+++ b/tests/test_parse_save_env.py
@@ -24,30 +24,51 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
         mock_environ.__setitem__.assert_any_call("TEST_KEY", "TEST_VALUE")
         mock_environ.__setitem__.assert_any_call("ANOTHER_KEY", "ANOTHER_VALUE")
 
+    @patch("autodialer.config.config.dotenv.set_key")
+    @patch("autodialer.config.config.os.environ")
+    @patch("autodialer.config.config.Path")
     @patch("autodialer.config.config.logger")
-    def test_parse_and_save_env_flags_no_env_value(self, mock_logger):
+    def test_parse_and_save_env_flags_no_env_value(
+        self, mock_logger, mock_path, mock_environ, mock_set_key
+    ):
+        mock_path.return_value.exists.return_value = True
         self.assertEqual(parse_and_save_env_flags(["PANEL_PASSWORD="]), False)
         mock_logger.error.assert_called_with(
             "Error: -e/--env requires a KEY=VALUE argument "
             "(e.g., -e PANEL_PASSWORD=secret)."
         )
 
+    @patch("autodialer.config.config.dotenv.set_key")
+    @patch("autodialer.config.config.os.environ")
+    @patch("autodialer.config.config.Path")
     @patch("autodialer.config.config.logger")
-    def test_parse_and_save_env_flags_invalid_format(self, mock_logger):
+    def test_parse_and_save_env_flags_invalid_format(
+        self, mock_logger, mock_path, mock_environ, mock_set_key
+    ):
+        mock_path.return_value.exists.return_value = True
         self.assertEqual(parse_and_save_env_flags(["INVALID_FORMAT"]), False)
         mock_logger.error.assert_called_with(
             "Error: -e/--env requires a KEY=VALUE argument "
             "(e.g., -e PANEL_PASSWORD=secret)."
         )
 
+    @patch("autodialer.config.config.Path")
+    @patch("autodialer.config.config.dotenv.set_key")
     @patch("autodialer.config.config.os.environ")
-    def test_only_save_env_var_when_all_args_valid(self, mock_environ):
+    def test_only_save_env_var_when_all_args_valid(
+        self, mock_environ, mock_set_key, mock_path
+    ):
         env_flags = ["password=123", "invalid"]
         self.assertEqual(parse_and_save_env_flags(env_flags), False)
         mock_environ.assert_not_called()
+        mock_set_key.assert_not_called()
 
+    @patch("autodialer.config.config.Path")
+    @patch("autodialer.config.config.dotenv.set_key")
     @patch("autodialer.config.config.os.environ")
-    def test_only_save_env_var_when_all_args_valid_2(self, mock_environ):
+    def test_only_save_env_var_when_all_args_valid_2(
+        self, mock_environ, mock_set_key, mock_path
+    ):
         env_flags = ["password=123", "username=123"]
         self.assertEqual(parse_and_save_env_flags(env_flags), True)
         mock_environ.__setitem__.assert_any_call("password", "123")

--- a/tests/test_parse_save_env.py
+++ b/tests/test_parse_save_env.py
@@ -26,9 +26,7 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
 
     @patch("autodialer.config.config.logger")
     def test_parse_and_save_env_flags_no_env_value(self, mock_logger):
-        with self.assertRaises(SystemExit) as context:
-            parse_and_save_env_flags(["PANEL_PASSWORD="])
-        self.assertTrue(context.exception.code != 0)
+        self.assertEqual(parse_and_save_env_flags(["PANEL_PASSWORD="]), False)
         mock_logger.error.assert_called_with(
             "Error: -e/--env requires a KEY=VALUE argument "
             "(e.g., -e PANEL_PASSWORD=secret)."
@@ -36,9 +34,7 @@ class TestParseAndSaveEnvFlags(unittest.TestCase):
 
     @patch("autodialer.config.config.logger")
     def test_parse_and_save_env_flags_invalid_format(self, mock_logger):
-        with self.assertRaises(SystemExit) as context:
-            parse_and_save_env_flags(["INVALID_FORMAT"])
-        self.assertTrue(context.exception.code != 0)
+        self.assertEqual(parse_and_save_env_flags(["INVALID_FORMAT"]), False)
         mock_logger.error.assert_called_with(
             "Error: -e/--env requires a KEY=VALUE argument "
             "(e.g., -e PANEL_PASSWORD=secret)."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened CLI argument validation so an action option is required (or the command stops with a clear error).
  * Improved `--env` handling: validates `KEY=VALUE`, supports multiple entries, updates environment on success, and fails gracefully on invalid input.
* **Tests**
  * Updated and expanded coverage for missing/invalid `--env` values and for correct behavior when combining `--env` with other flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->