### PR TITLE
Refactor: refactor RouterAPI class, customize exception, rename routers' methods

### DIFF
--- a/src/autodialer/__init__.py
+++ b/src/autodialer/__init__.py
@@ -2,17 +2,12 @@ __version__ = "0.4.0"
 __author__ = "Byteflow"
 
 
-TYPE_CHECKING = False
-
-if TYPE_CHECKING:
+if False:
     from autodialer.get_devices import get_devices, print_devices_table
     from autodialer.reconnection import reconnect
+    from autodialer.routers import RouterAPI, get_router
 
-__all__ = [
-    "get_devices",
-    "print_devices_table",
-    "reconnect",
-]
+__all__ = ["get_devices", "print_devices_table", "reconnect", "RouterAPI", "get_router"]
 
 
 def __getattr__(name):
@@ -21,13 +16,21 @@ def __getattr__(name):
 
         return get_devices
     elif name == "print_devices_table":
-        from .get_devices import print_devices_table
+        from autodialer.get_devices import print_devices_table
 
         return print_devices_table
     elif name == "reconnect":
-        from .reconnection import reconnect
+        from autodialer.reconnection import reconnect
 
         return reconnect
+    elif name == "RouterAPI":
+        from autodialer.routers import RouterAPI
+
+        return RouterAPI
+    elif name == "get_router":
+        from autodialer.network import get_router
+
+        return get_router
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/autodialer/__init__.py
+++ b/src/autodialer/__init__.py
@@ -1,11 +1,13 @@
 __version__ = "0.4.0"
 __author__ = "Byteflow"
 
+from typing import TYPE_CHECKING
 
-if False:
+if TYPE_CHECKING:
     from autodialer.get_devices import get_devices, print_devices_table
+    from autodialer.network import get_router
     from autodialer.reconnection import reconnect
-    from autodialer.routers import RouterAPI, get_router
+    from autodialer.routers import RouterAPI
 
 __all__ = ["get_devices", "print_devices_table", "reconnect", "RouterAPI", "get_router"]
 
@@ -32,7 +34,3 @@ def __getattr__(name):
 
         return get_router
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals().keys()) | set(__all__))

--- a/src/autodialer/cli.py
+++ b/src/autodialer/cli.py
@@ -2,6 +2,8 @@ import argparse
 import sys
 
 from autodialer import __version__
+from autodialer.get_devices import DeviceRetrievalError
+from autodialer.reconnection import ReconnectionError
 from autodialer.utils import validate_asn
 
 
@@ -89,7 +91,7 @@ def main():
 
         try:
             print_devices_table()
-        except RuntimeError as e:
+        except DeviceRetrievalError as e:
             # Lazy import logging as it has a not low overhead, and
             # should never be used when the user just wants
             # to see the help message or print devices
@@ -111,7 +113,7 @@ def main():
                 reconnect(mode="asn", asn=args.asn, max_attempts=args.attempts)
             elif args.change:
                 reconnect(mode="change", max_attempts=args.attempts)
-        except RuntimeError as e:
+        except ReconnectionError as e:
             import logging
 
             logger = logging.getLogger(__name__)

--- a/src/autodialer/get_devices.py
+++ b/src/autodialer/get_devices.py
@@ -3,10 +3,16 @@ import sys
 from autodialer.network.get_router import get_router
 
 
+class DeviceRetrievalError(RuntimeError):
+    """Custom exception for device retrieval errors."""
+
+
 def get_devices() -> list:
     router = get_router()
     if router is None:
-        raise RuntimeError("Unable to detect router vendor or no API available.")
+        raise DeviceRetrievalError(
+            "Unable to detect router vendor or no API available."
+        )
     devices = router.get_connected_devices()
     return devices
 

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -36,10 +36,12 @@ class Reconnector:
         elif mode == "change":
             return self._reconnect_util_change_ip(max_attempts)
         elif mode == "asn":
+            if asn is None:
+                raise ReconnectionError("Target ASN must be provided for ASN mode.")
             if not self._validate_asn(asn):
                 return
             return self._reconnect_util_target_asn(
-                target_asn=asn,  # type: ignore
+                target_asn=asn,
                 max_attempts=max_attempts,
             )
         else:
@@ -122,8 +124,9 @@ class Reconnector:
         )
 
     def _validate_asn(self, asn: str | None) -> bool:
-        if asn is None:
-            raise ReconnectionError("Target ASN must be provided for ASN mode.")
+        # Used for ASN mode to check if the current ASN matches the target ASN.
+        # If cannot fetch current ASN, raise an error.
+        # If already connected to the target ASN, log and return False.
         current_isp = check_isp_with_retries()
         if current_isp is None:
             raise ReconnectionError("Unable to fetch ISP information.")

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -122,6 +122,8 @@ class Reconnector:
         )
 
     def _validate_asn(self, asn: str | None) -> bool:
+        if asn is None:
+            raise ReconnectionError("Target ASN must be provided for ASN mode.")
         current_isp = check_isp_with_retries()
         if current_isp is None:
             raise ReconnectionError("Unable to fetch ISP information.")
@@ -131,8 +133,6 @@ class Reconnector:
                 asn,
             )
             return False
-        if asn is None:
-            raise ReconnectionError("Target ASN must be provided for ASN mode.")
         return True
 
 

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -12,150 +12,139 @@ from autodialer.utils import is_target_asn
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_MAX_ATTEMPTS = 5
+
+
+class ReconnectionError(RuntimeError):
+    """Custom exception for reconnection-related errors."""
+
 
 class Reconnector:
-    DEFAULT_MAX_ATTEMPTS = 5
-
-    def __init__(self, router: RouterAPI, delay: int = 10):
+    def __init__(self, router: RouterAPI, delay: int = 10) -> None:
         self.router = router
         self.delay = delay
-
-    def _get_wan_proto(self) -> str | None:
-        return self.router.get_wan_proto()
-
-    def _apply_reconnection(self, proto: str) -> bool:
-        if proto == "pppoe":
-            return self.router.make_pppoe_reconnection()
-        if proto == "dhcp":
-            return self.router.dhcp_renew()
-
-        logger.error("Unsupported WAN protocol: %s", proto)
-        return False
 
     def run_reconnection(
         self,
         mode: Literal["force", "asn", "change"],
         *,
         asn: str | None,
-        max_attempts: int | None = None,
+        max_attempts: int,
     ) -> None:
-        if max_attempts is None:
-            max_attempts = self.DEFAULT_MAX_ATTEMPTS
+        if mode == "force":
+            return self._reconnect_forcefully(max_attempts)
+        elif mode == "change":
+            return self._reconnect_util_change_ip(max_attempts)
+        elif mode == "asn":
+            if not self._validate_asn(asn):
+                return
+            return self._reconnect_util_target_asn(
+                target_asn=asn,  # type: ignore
+                max_attempts=max_attempts,
+            )
+        else:
+            raise ReconnectionError(f"Invalid reconnection mode: {mode}")
 
-        proto = self._get_wan_proto()
+    def _reconnect_forcefully(self, max_attempts: int) -> None:
+        if not self.router.restart_wan():
+            raise ReconnectionError("Failed to apply forced reconnection.")
 
-        if proto is None:
-            raise RuntimeError("Unable to determine current WAN protocol.")
+        if not get_internet_connectivity(self.delay, max_attempts):
+            raise ReconnectionError(
+                "Cannot detect internet connectivity after forced reconnection."
+            )
 
-        match mode:
-            case "force":
-                if not self._apply_reconnection(proto):
-                    raise RuntimeError("Failed to apply forced reconnection.")
+        isp = check_isp_with_retries()
+        ip = get_ip_address()
+        if isp and ip is not None:
+            logger.info("IP info after forced reconnection: %s %s", ip, isp)
+        else:
+            logger.warning(
+                "Forced reconnection completed, but unable to fetch IP info."
+            )
+        return
 
-                if not get_internet_connectivity(self.delay, max_attempts):
-                    raise RuntimeError(
-                        "Cannot detect internet connectivity after forced reconnection."
-                    )
+    def _reconnect_util_change_ip(self, max_attempts: int) -> None:
+        if (current_ip := get_ip_address()) is None:
+            raise ReconnectionError("Unable to fetch current IP address.")
 
-                isp = check_isp_with_retries()
-                ip = get_ip_address()
-                if isp and ip is not None:
-                    logger.info("IP info after forced reconnection: %s %s", ip, isp)
-                else:
-                    logger.warning(
-                        "Forced reconnection completed, but unable to fetch IP info."
-                    )
+        after_reconnection_ip: str | None = current_ip
+        attempts = 0
+
+        while (current_ip == after_reconnection_ip) and attempts < max_attempts:
+            if not self.router.restart_wan():
+                raise ReconnectionError("Failed to apply reconnection.")
+
+            if not get_internet_connectivity(self.delay, max_attempts):
+                raise ReconnectionError(
+                    "Cannot detect internet connectivity after reconnection."
+                )
+
+            if (after_reconnection_ip := get_ip_address()) is None:
+                raise ReconnectionError(
+                    "Unable to fetch IP address after reconnection."
+                )
+            attempts += 1
+
+        if current_ip != after_reconnection_ip:
+            isp = check_isp_with_retries()
+            logger.info(
+                "IP info after reconnection: %s -> %s %s",
+                current_ip,
+                after_reconnection_ip,
+                isp,
+            )
+            return
+        raise ReconnectionError(
+            f"Failed to change IP address after {max_attempts} attempts."
+        )
+
+    def _reconnect_util_target_asn(self, target_asn: str, max_attempts: int) -> None:
+        for _ in range(max_attempts):
+            if not self.router.restart_wan():
+                raise ReconnectionError("Failed to apply reconnection.")
+
+            if not get_internet_connectivity(self.delay, max_attempts):
+                raise ReconnectionError(
+                    "Cannot detect internet connectivity after reconnection."
+                )
+
+            isp = check_isp_with_retries()
+            if isp is None:
+                raise ReconnectionError("Unable to fetch ISP information.")
+
+            if is_target_asn(current_isp=isp, target_asn=target_asn):
                 return
 
-            case "change":
-                if (current_ip := get_ip_address()) is None:
-                    raise RuntimeError("Unable to fetch current IP address.")
+        raise ReconnectionError(
+            "Reached maximum reconnection attempts without "
+            "switching to the desired ASN."
+        )
 
-                after_reconnection_ip: str | None = current_ip
-                attempts = 0
-
-                while (current_ip == after_reconnection_ip) and attempts < max_attempts:
-                    if not self._apply_reconnection(proto):
-                        raise RuntimeError("Failed to apply reconnection.")
-
-                    if not get_internet_connectivity(self.delay, max_attempts):
-                        raise RuntimeError(
-                            "Cannot detect internet connectivity after reconnection."
-                        )
-
-                    if (after_reconnection_ip := get_ip_address()) is None:
-                        raise RuntimeError(
-                            "Unable to fetch IP address after reconnection."
-                        )
-                    attempts += 1
-
-                if current_ip != after_reconnection_ip:
-                    isp = check_isp_with_retries()
-                    logger.info(
-                        "IP info after reconnection: %s -> %s %s",
-                        current_ip,
-                        after_reconnection_ip,
-                        isp,
-                    )
-                    return
-                raise RuntimeError(
-                    f"Failed to change IP address after {max_attempts} attempts."
-                )
-
-            case "asn":
-                for _ in range(max_attempts):
-                    if not self._apply_reconnection(proto):
-                        raise RuntimeError("Failed to apply reconnection.")
-
-                    if not get_internet_connectivity(self.delay, max_attempts):
-                        raise RuntimeError(
-                            "Cannot detect internet connectivity after reconnection."
-                        )
-
-                    isp = check_isp_with_retries()
-                    if isp is None:
-                        raise RuntimeError("Unable to fetch ISP information.")
-
-                    if is_target_asn(current_isp=isp, target_asn=asn):
-                        return
-
-                raise RuntimeError(
-                    "Reached maximum reconnection attempts without "
-                    "switching to the desired ASN."
-                )
-
-    def main(
-        self,
-        mode: Literal["force", "asn", "change"],
-        asn: str | None = None,
-        max_attempts: int | None = None,
-    ) -> None:
-        match mode:
-            case "force":
-                self.run_reconnection(mode="force", asn=None, max_attempts=max_attempts)
-            case "asn":
-                if is_target_asn(current_isp=check_isp_with_retries(), target_asn=asn):
-                    logger.info(
-                        "Already connected to target ASN %s. No reconnection needed.",
-                        asn,
-                    )
-                    return
-                self.run_reconnection(mode="asn", asn=asn, max_attempts=max_attempts)
-            case "change":
-                self.run_reconnection(
-                    mode="change", asn=None, max_attempts=max_attempts
-                )
+    def _validate_asn(self, asn: str | None) -> bool:
+        current_isp = check_isp_with_retries()
+        if current_isp is None:
+            raise ReconnectionError("Unable to fetch ISP information.")
+        if is_target_asn(current_isp=current_isp, target_asn=asn):
+            logger.info(
+                "Already connected to target ASN %s. No reconnection needed.",
+                asn,
+            )
+            return False
+        if asn is None:
+            raise ReconnectionError("Target ASN must be provided for ASN mode.")
+        return True
 
 
 def reconnect(
     *,
     mode: Literal["force", "asn", "change"],
     asn: str | None = None,
-    max_attempts: int | None = None,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
 ) -> None:
 
     router = get_router()
     if router is None:
-        raise RuntimeError("Unable to detect router vendor or no API available.")
+        raise ReconnectionError("Unable to detect router vendor or no API available.")
     reconnector = Reconnector(router)
-    reconnector.main(mode, asn, max_attempts)
+    reconnector.run_reconnection(mode=mode, max_attempts=max_attempts, asn=asn)

--- a/src/autodialer/reconnection.py
+++ b/src/autodialer/reconnection.py
@@ -142,6 +142,8 @@ def reconnect(
     asn: str | None = None,
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
 ) -> None:
+    if max_attempts <= 0:
+        raise ReconnectionError("The value of attempts must be at least 1.")
 
     router = get_router()
     if router is None:

--- a/src/autodialer/routers/asus/asus_api.py
+++ b/src/autodialer/routers/asus/asus_api.py
@@ -384,7 +384,7 @@ class AsusAPI(RouterAPI):
 
         return any(self._run_service(service) for service in services_to_try)
 
-    def make_pppoe_reconnection(self) -> bool:
+    def pppoe_restart(self) -> bool:
         if self._restart_wan():
             return True
 

--- a/src/autodialer/routers/base_router_api.py
+++ b/src/autodialer/routers/base_router_api.py
@@ -6,29 +6,24 @@ class AbstractRouterAPI(ABC):
     SUPPORTED_VENDORS: ClassVar[tuple[str, ...]]
 
     @abstractmethod
-    def get_wan_proto(self) -> str | None: ...
-
-    """Return the lower case of WLAN protocol, i.e. (pppoe,dhcp)."""
-
-    @abstractmethod
-    def pppoe_restart(self) -> bool: ...
-
-    """Restart the router by PPPoE protocol."""
+    def get_wan_proto(self) -> str | None:
+        """Return the lower case of WLAN protocol, i.e. (pppoe,dhcp)."""
 
     @abstractmethod
-    def dhcp_renew(self) -> bool: ...
-
-    """Restart the router by DHCP protocol."""
-
-    @abstractmethod
-    def restart_wan(self) -> bool: ...
-
-    """Restart the router."""
+    def pppoe_restart(self) -> bool:
+        """Restart the router by PPPoE protocol."""
 
     @abstractmethod
-    def get_connected_devices(self) -> list: ...
+    def dhcp_renew(self) -> bool:
+        """Restart the router by DHCP protocol."""
 
-    """Get the infomation of connected devices."""
+    @abstractmethod
+    def restart_wan(self) -> bool:
+        """Restart the router."""
+
+    @abstractmethod
+    def get_connected_devices(self) -> list:
+        """Get the information of connected devices."""
 
 
 class RouterAPI(AbstractRouterAPI):

--- a/src/autodialer/routers/base_router_api.py
+++ b/src/autodialer/routers/base_router_api.py
@@ -8,17 +8,27 @@ class AbstractRouterAPI(ABC):
     @abstractmethod
     def get_wan_proto(self) -> str | None: ...
 
+    """Return the lower case of WLAN protocol, i.e. (pppoe,dhcp)."""
+
     @abstractmethod
     def pppoe_restart(self) -> bool: ...
+
+    """Restart the router by PPPoE protocol."""
 
     @abstractmethod
     def dhcp_renew(self) -> bool: ...
 
+    """Restart the router by DHCP protocol."""
+
     @abstractmethod
     def restart_wan(self) -> bool: ...
 
+    """Restart the router."""
+
     @abstractmethod
     def get_connected_devices(self) -> list: ...
+
+    """Get the infomation of connected devices."""
 
 
 class RouterAPI(AbstractRouterAPI):

--- a/src/autodialer/routers/base_router_api.py
+++ b/src/autodialer/routers/base_router_api.py
@@ -31,7 +31,8 @@ class RouterAPI(AbstractRouterAPI):
         proto = self.get_wan_proto()
         if proto is None:
             return False
-        elif proto == "dhcp":
+        proto = proto.strip().lower()
+        if proto == "dhcp":
             return self.dhcp_renew()
         elif proto == "pppoe":
             return self.pppoe_restart()

--- a/src/autodialer/routers/base_router_api.py
+++ b/src/autodialer/routers/base_router_api.py
@@ -2,17 +2,32 @@ from abc import ABC, abstractmethod
 from typing import ClassVar
 
 
-class RouterAPI(ABC):
+class AbstractRouterAPI(ABC):
     SUPPORTED_VENDORS: ClassVar[tuple[str, ...]]
 
     @abstractmethod
     def get_wan_proto(self) -> str | None: ...
 
     @abstractmethod
-    def make_pppoe_reconnection(self) -> bool: ...
+    def pppoe_restart(self) -> bool: ...
 
     @abstractmethod
     def dhcp_renew(self) -> bool: ...
 
     @abstractmethod
+    def restart_wan(self) -> bool: ...
+
+    @abstractmethod
     def get_connected_devices(self) -> list: ...
+
+
+class RouterAPI(AbstractRouterAPI):
+    def restart_wan(self) -> bool:
+        proto = self.get_wan_proto()
+        if proto is None:
+            return False
+        elif proto == "dhcp":
+            return self.dhcp_renew()
+        elif proto == "pppoe":
+            return self.pppoe_restart()
+        return False

--- a/src/autodialer/routers/tplink/tplink_api.py
+++ b/src/autodialer/routers/tplink/tplink_api.py
@@ -80,7 +80,7 @@ class TPLinkAPI(RouterAPI):
             sys.exit(1)
         return stok if isinstance(stok, str) else None
 
-    def set_credentials(self) -> bool:
+    def _set_credentials(self) -> bool:
         if not self.username or not self.pppoe_password:
             logger.warning(
                 "Missing PPPoE credentials override. "
@@ -103,7 +103,7 @@ class TPLinkAPI(RouterAPI):
             return False
         return True
 
-    def tplink_change_wan_status_request(
+    def _tplink_change_wan_status_request(
         self, action: Literal["connect", "disconnect", "renew"], method: str, proto: str
     ) -> bool:
         payload = {
@@ -117,7 +117,7 @@ class TPLinkAPI(RouterAPI):
             return False
         return True
 
-    def tplink_get_wan_status(self) -> dict:
+    def _tplink_get_wan_status(self) -> dict:
         payload = {
             "network": {"name": ["wan_status", "wanv6_status"]},
             "protocol": {"name": ["dhcp", "ipv6_info"]},
@@ -131,23 +131,28 @@ class TPLinkAPI(RouterAPI):
         return response
 
     def get_wan_proto(self) -> str | None:
-        status = self.tplink_get_wan_status()
+        status = self._tplink_get_wan_status()
         wan_status = status.get("network", {}).get("wan_status", {})
         proto = wan_status.get("proto")
         return proto if isinstance(proto, str) else None
 
-    def make_pppoe_reconnection(self) -> bool:
+    def pppoe_restart(self) -> bool:
 
-        if self.username and self.pppoe_password and not self.set_credentials():
+        if self.username and self.pppoe_password and not self._set_credentials():
             return False
 
-        if not self.tplink_change_wan_status_request(
+        if not self._tplink_change_wan_status_request(
             action="disconnect", method="do", proto="pppoe"
         ):
             return False
 
-        return self.tplink_change_wan_status_request(
+        return self._tplink_change_wan_status_request(
             action="connect", method="do", proto="pppoe"
+        )
+
+    def dhcp_renew(self) -> bool:
+        return self._tplink_change_wan_status_request(
+            action="renew", method="do", proto="dhcp"
         )
 
     def get_connected_devices(self) -> list:
@@ -182,8 +187,3 @@ class TPLinkAPI(RouterAPI):
                 }
             )
         return devices
-
-    def dhcp_renew(self) -> bool:
-        return self.tplink_change_wan_status_request(
-            action="renew", method="do", proto="dhcp"
-        )

--- a/src/autodialer/routers/tplink/tplink_api.py
+++ b/src/autodialer/routers/tplink/tplink_api.py
@@ -134,7 +134,7 @@ class TPLinkAPI(RouterAPI):
         status = self._tplink_get_wan_status()
         wan_status = status.get("network", {}).get("wan_status", {})
         proto = wan_status.get("proto")
-        return proto if isinstance(proto, str) else None
+        return proto.lower() if isinstance(proto, str) else None
 
     def pppoe_restart(self) -> bool:
 

--- a/src/autodialer/routers/zte/zte_api.py
+++ b/src/autodialer/routers/zte/zte_api.py
@@ -292,7 +292,7 @@ class ZTEApi(RouterAPI):
             logger.error("Failed to get WAN protocol: %s", e)
             return None
 
-    def make_pppoe_reconnection(self) -> bool:
+    def pppoe_restart(self) -> bool:
         first_attempt = self._restart_once()
         if first_attempt == "success":
             return True

--- a/tests/test_get_devices.py
+++ b/tests/test_get_devices.py
@@ -2,6 +2,8 @@ import importlib
 import unittest
 from unittest.mock import patch
 
+from autodialer.get_devices import DeviceRetrievalError
+
 get_devices_module = importlib.import_module("autodialer.get_devices")
 
 
@@ -73,7 +75,7 @@ class TestGetDevices(unittest.TestCase):
     def test_get_devices_raises_runtime_error_when_router_none(self, mock_get_router):
         from autodialer.get_devices import get_devices
 
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(DeviceRetrievalError) as context:
             get_devices()
         self.assertIn(
             "Unable to detect router vendor or no API available.",

--- a/tests/test_get_router.py
+++ b/tests/test_get_router.py
@@ -19,7 +19,7 @@ class TestGetRouter(unittest.TestCase):
 
         self.assertTrue(hasattr(router, "get_wan_proto"))
         self.assertTrue(hasattr(router, "dhcp_renew"))
-        self.assertTrue(hasattr(router, "make_pppoe_reconnection"))
+        self.assertTrue(hasattr(router, "pppoe_restart"))
         self.assertTrue(hasattr(router, "get_connected_devices"))
 
     @patch.object(get_router_module, "check_router_vendor", return_value=None)

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -17,22 +17,47 @@ class TestReconnection(unittest.TestCase):
         router.pppoe_restart.return_value = reconnect_result
         return router
 
-    def test_get_wan_proto_uses_router_contract(self):
-        router = Mock()
-        router.get_wan_proto.return_value = "dhcp"
+    def test_router_api_restart_wan_dhcp(self):
+        from autodialer.routers import RouterAPI
 
-        reconnector = reconnection_module.Reconnector(router)
+        class MockRouter(RouterAPI):
+            SUPPORTED_VENDORS = ("Mock",)
 
-        self.assertEqual(reconnector.router.get_wan_proto(), "dhcp")
+            def get_wan_proto(self):
+                return "dhcp"
 
-    def test_apply_reconnection_calls_pppoe_method(self):
-        router = Mock()
-        router.pppoe_restart.return_value = True
+            def pppoe_restart(self):
+                return False
 
-        reconnector = reconnection_module.Reconnector(router)
+            def dhcp_renew(self):
+                return True
 
-        self.assertTrue(reconnector.router.pppoe_restart())
-        router.pppoe_restart.assert_called_once_with()
+            def get_connected_devices(self):
+                return []
+
+        router = MockRouter()
+        self.assertTrue(router.restart_wan())
+
+    def test_router_api_restart_wan_pppoe(self):
+        from autodialer.routers import RouterAPI
+
+        class MockRouter(RouterAPI):
+            SUPPORTED_VENDORS = ("Mock",)
+
+            def get_wan_proto(self):
+                return "pppoe"
+
+            def pppoe_restart(self):
+                return True
+
+            def dhcp_renew(self):
+                return False
+
+            def get_connected_devices(self):
+                return []
+
+        router = MockRouter()
+        self.assertTrue(router.restart_wan())
 
     @patch("builtins.exit")
     @patch.object(reconnection_module, "is_target_asn")
@@ -185,8 +210,7 @@ class TestReconnection(unittest.TestCase):
         router.restart_wan.assert_not_called()
 
     @patch.object(reconnection_module, "get_router", return_value=None)
-    @patch.object(reconnection_module, "logger")
-    def test_reconnect_exits_when_no_router(self, mock_logger, mock_get_router):
+    def test_reconnect_exits_when_no_router(self, mock_get_router):
         with self.assertRaises(ReconnectionError) as context:
             reconnection_module.reconnect(mode="force")
         self.assertEqual(
@@ -194,6 +218,14 @@ class TestReconnection(unittest.TestCase):
             "Unable to detect router vendor or no API available.",
         )
         mock_get_router.assert_called_once_with()
+
+    @patch.object(reconnection_module, "get_router", return_value=None)
+    def test_reconnect_reject_illegal_attempts(self, mock_get_router):
+        with self.assertRaises(ReconnectionError) as context:
+            reconnection_module.reconnect(mode="force", max_attempts=0)
+        self.assertEqual(
+            str(context.exception), "The value of attempts must be at least 1."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -3,6 +3,8 @@ import unittest
 from typing import Any
 from unittest.mock import Mock, patch
 
+from autodialer.reconnection import ReconnectionError
+
 reconnection_module = importlib.import_module("autodialer.reconnection")
 
 
@@ -12,25 +14,25 @@ class TestReconnection(unittest.TestCase):
         router = Mock()
         router.get_wan_proto.return_value = proto
         router.dhcp_renew.return_value = reconnect_result
-        router.make_pppoe_reconnection.return_value = reconnect_result
+        router.pppoe_restart.return_value = reconnect_result
         return router
 
     def test_get_wan_proto_uses_router_contract(self):
         router = Mock()
         router.get_wan_proto.return_value = "dhcp"
 
-        reconnection = reconnection_module.Reconnector(router)
+        reconnector = reconnection_module.Reconnector(router)
 
-        self.assertEqual(reconnection._get_wan_proto(), "dhcp")
+        self.assertEqual(reconnector.router.get_wan_proto(), "dhcp")
 
     def test_apply_reconnection_calls_pppoe_method(self):
         router = Mock()
-        router.make_pppoe_reconnection.return_value = True
+        router.pppoe_restart.return_value = True
 
-        reconnection = reconnection_module.Reconnector(router)
+        reconnector = reconnection_module.Reconnector(router)
 
-        self.assertTrue(reconnection._apply_reconnection("pppoe"))
-        router.make_pppoe_reconnection.assert_called_once_with()
+        self.assertTrue(reconnector.router.pppoe_restart())
+        router.pppoe_restart.assert_called_once_with()
 
     @patch("builtins.exit")
     @patch.object(reconnection_module, "is_target_asn")
@@ -44,7 +46,7 @@ class TestReconnection(unittest.TestCase):
         mock_exit: Any,
     ):
         router = self._make_router(proto="dhcp")
-        reconnection = reconnection_module.Reconnector(router, delay=7)
+        reconnector = reconnection_module.Reconnector(router, delay=7)
 
         events: list[str] = []
         isp_values = iter(["AS111 Example ISP", "AS222 Target ISP"])
@@ -67,14 +69,14 @@ class TestReconnection(unittest.TestCase):
         mock_check_isp_with_retries.side_effect = isp_side_effect
         mock_is_target_asn.side_effect = is_target_side_effect
 
-        reconnection.run_reconnection(mode="asn", asn="AS222", max_attempts=3)
+        reconnector.run_reconnection(mode="asn", asn="AS222", max_attempts=1)
 
-        self.assertEqual(router.dhcp_renew.call_count, 2)
-        self.assertEqual(mock_get_internet_connectivity.call_count, 2)
+        self.assertEqual(router.restart_wan.call_count, 1)
+        self.assertEqual(mock_get_internet_connectivity.call_count, 1)
         self.assertEqual(mock_check_isp_with_retries.call_count, 2)
         self.assertEqual(
             events,
-            ["sleep", "check_isp", "is_target", "sleep", "check_isp", "is_target"],
+            ["check_isp", "is_target", "sleep", "check_isp", "is_target"],
         )
         mock_exit.assert_not_called()
 
@@ -88,14 +90,14 @@ class TestReconnection(unittest.TestCase):
         mock_exit: Any,
     ):
         router = self._make_router()
-        reconnection = reconnection_module.Reconnector(router)
+        reconnector = reconnection_module.Reconnector(router)
 
-        with self.assertRaises(RuntimeError) as context:
-            reconnection.run_reconnection(mode="change", asn=None)
+        with self.assertRaises(ReconnectionError) as context:
+            reconnector.run_reconnection(mode="change", max_attempts=5, asn=None)
 
         self.assertEqual(str(context.exception), "Unable to fetch current IP address.")
         mock_get_ip_address.assert_called_once_with()
-        router.dhcp_renew.assert_not_called()
+        router.restart_wan.assert_not_called()
         mock_exit.assert_not_called()
 
     @patch("sys.exit")
@@ -118,11 +120,11 @@ class TestReconnection(unittest.TestCase):
         mock_exit: Any,
     ):
         router = self._make_router()
-        reconnection = reconnection_module.Reconnector(router)
+        reconnector = reconnection_module.Reconnector(router)
 
-        reconnection.run_reconnection(mode="change", asn=None)
+        reconnector.run_reconnection(mode="change", max_attempts=5, asn=None)
 
-        self.assertEqual(router.dhcp_renew.call_count, 2)
+        self.assertEqual(router.restart_wan.call_count, 2)
         self.assertEqual(mock_get_ip_address.call_count, 3)
         mock_logger_info.assert_called_with(
             "IP info after reconnection: %s -> %s %s",
@@ -152,15 +154,15 @@ class TestReconnection(unittest.TestCase):
         mock_exit: Any,
     ):
         router = self._make_router()
-        reconnection = reconnection_module.Reconnector(router)
+        reconnector = reconnection_module.Reconnector(router)
 
-        with self.assertRaises(RuntimeError) as context:
-            reconnection.run_reconnection(mode="change", asn=None, max_attempts=3)
+        with self.assertRaises(ReconnectionError) as context:
+            reconnector.run_reconnection(mode="change", max_attempts=3, asn=None)
 
         self.assertEqual(
             str(context.exception), "Failed to change IP address after 3 attempts."
         )
-        self.assertEqual(router.dhcp_renew.call_count, 3)
+        self.assertEqual(router.restart_wan.call_count, 3)
         self.assertEqual(mock_get_ip_address.call_count, 4)
         mock_exit.assert_not_called()
 
@@ -180,12 +182,12 @@ class TestReconnection(unittest.TestCase):
 
         reconnection_module.reconnect(mode="asn", asn="AS9929")
 
-        router.get_wan_proto.assert_not_called()
+        router.restart_wan.assert_not_called()
 
     @patch.object(reconnection_module, "get_router", return_value=None)
     @patch.object(reconnection_module, "logger")
     def test_reconnect_exits_when_no_router(self, mock_logger, mock_get_router):
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(ReconnectionError) as context:
             reconnection_module.reconnect(mode="force")
         self.assertEqual(
             str(context.exception),

--- a/tests/test_tplink_api.py
+++ b/tests/test_tplink_api.py
@@ -31,7 +31,7 @@ class TestTPLinkAPI(unittest.TestCase):
 
         router = TPLinkAPI()
 
-        result = router.make_pppoe_reconnection()
+        result = router.pppoe_restart()
 
         self.assertTrue(result)
 
@@ -60,7 +60,7 @@ class TestTPLinkAPI(unittest.TestCase):
 
         router = TPLinkAPI()
 
-        result = router.make_pppoe_reconnection()
+        result = router.pppoe_restart()
 
         self.assertTrue(result)
 
@@ -88,11 +88,11 @@ class TestTPLinkAPI(unittest.TestCase):
         with (
             patch.object(
                 router,
-                "tplink_change_wan_status_request",
-                wraps=router.tplink_change_wan_status_request,
+                "_tplink_change_wan_status_request",
+                wraps=router._tplink_change_wan_status_request,
             ) as mock_change_status,
         ):
-            result = router.make_pppoe_reconnection()
+            result = router.pppoe_restart()
 
         self.assertFalse(result)
         mock_change_status.assert_not_called()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded public API with new `RouterAPI` and `get_router` exports.
  * Improved reconnection workflow using router-level WAN restarts, with a default of 5 attempts.

* **Bug Fixes**
  * Enhanced error reporting with dedicated `DeviceRetrievalError` and `ReconnectionError` types (including updated CLI handling).

* **Breaking Changes**
  * Router PPPoE reconnection method was renamed to `pppoe_restart` (replacing the previous PPPoE restart entry point).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->